### PR TITLE
Added support of `--with-boost-check` option.

### DIFF
--- a/boost/jamfile
+++ b/boost/jamfile
@@ -349,65 +349,67 @@ $(PROPERTY_DUMP_COMMANDS)
     rm -f '$(FULL_PREFIX)/lib/libboost_test_exec_monitor.a'
   fi
 
-  # Because some Boost test cases hang up on some environments, resource for
-  # processes shoud be limited in order for the processes to terminate in a
-  # reasonable length of time.
-  ulimit -St 1200
-  ulimit -Sm 2097152
-  # Because many Boost test cases crash, core files should be prevented from
-  # occupying large portion of disk space.
-  ulimit -Sc 0
+  if [ $(BOOST_CHECK) = yes ]; then
+    # Because some Boost test cases hang up on some environments, resource
+    # for processes shoud be limited in order for the processes to terminate
+    # in a reasonable length of time.
+    ulimit -St 1200
+    ulimit -Sm 2097152
+    # Because many Boost test cases crash, core files should be prevented
+    # from occupying large portion of disk space.
+    ulimit -Sc 0
 
-  get_clamped_concurrency ()
-  {
-    concurrency=$1
-    memory_per_concurrency=$2
-    echo "$concurrency" | grep -Eq '^[[:digit:]]+$'
-    echo "$memory_per_concurrency" | grep -Eq '^[[:digit:]]+$'
-    [ -f /proc/meminfo ]
-    mem=`grep -Eo '^MemFree:[[:space:]]+[[:digit:]]+[[:space:]]+kB' /proc/meminfo`
-    mem=`echo $mem | grep -Eo '[[:digit:]]+'`
-    echo "$mem" | grep -Eq '^[[:digit:]]+$'
-    con=`expr $mem / $memory_per_concurrency`
-    if [ $con -lt $concurrency ]; then
-      if [ $con -gt 0 ]; then
-        concurrency=$con
-      else
-        concurrency=1
-      fi
-    fi
-    return $concurrency
-  }
-
-  for i in '$(BOOST_ROOT)'/libs/*/test; do
-    libname=`echo -n "$i" | sed -e 's@$(BOOST_ROOT)/libs/\([^/]\{1,\}\)/test@\1@'`
-    if [ "$libname" = detail ]; then
-      :
-    elif [ '$(LINK)' = shared -a "$libname" = exception ]; then
-      :
-    elif [ '$(THREADING)' = single -a \( "$libname" = locale -o "$libname" = thread -o "$libname" = wave \) ]; then
-      :
-    else
-      testdir="$(BOOST_ROOT)/libs/$libname/test"
-      [ -d "$testdir" ]
-      if [ -f "$testdir/Jamfile.v2" -o -f "$testdir/Jamfile" ]; then
-        if [ `echo $(CONCURRENCY) `x != x ]; then
-          concurrency=$(CONCURRENCY)
+    get_clamped_concurrency ()
+    {
+      concurrency=$1
+      memory_per_concurrency=$2
+      echo "$concurrency" | grep -Eq '^[[:digit:]]+$'
+      echo "$memory_per_concurrency" | grep -Eq '^[[:digit:]]+$'
+      [ -f /proc/meminfo ]
+      mem=`grep -Eo '^MemFree:[[:space:]]+[[:digit:]]+[[:space:]]+kB' /proc/meminfo`
+      mem=`echo $mem | grep -Eo '[[:digit:]]+'`
+      echo "$mem" | grep -Eq '^[[:digit:]]+$'
+      con=`expr $mem / $memory_per_concurrency`
+      if [ $con -lt $concurrency ]; then
+        if [ $con -gt 0 ]; then
+          concurrency=$con
         else
           concurrency=1
         fi
-        if [ "$libname" = multiprecision ]; then
-          memory_per_concurrency=2097152
-        elif [ "$libname" = geometry -o "$libname" = graph_parallel -o "$libname" = intrusive -o "$libname" = msm -o "$libname" = range -o "$libname" = spirit -o "$libname" = xpressive ]; then
-          memory_per_concurrency=1048576
-        else
-          memory_per_concurrency=524288
-        fi
-        get_clamped_concurrency $concurrency $memory_per_concurrency || concurrency=$?
-        ( cd "$testdir" && ../../../b2 -d+2 -j$concurrency $(OPTIONS) ) || true
       fi
-    fi
-  done
+      return $concurrency
+    }
+
+    for i in '$(BOOST_ROOT)'/libs/*/test; do
+      libname=`echo -n "$i" | sed -e 's@$(BOOST_ROOT)/libs/\([^/]\{1,\}\)/test@\1@'`
+      if [ "$libname" = detail ]; then
+        :
+      elif [ '$(LINK)' = shared -a "$libname" = exception ]; then
+        :
+      elif [ '$(THREADING)' = single -a \( "$libname" = locale -o "$libname" = thread -o "$libname" = wave \) ]; then
+        :
+      else
+        testdir="$(BOOST_ROOT)/libs/$libname/test"
+        [ -d "$testdir" ]
+        if [ -f "$testdir/Jamfile.v2" -o -f "$testdir/Jamfile" ]; then
+          if [ `echo $(CONCURRENCY) `x != x ]; then
+            concurrency=$(CONCURRENCY)
+          else
+            concurrency=1
+          fi
+          if [ "$libname" = multiprecision ]; then
+            memory_per_concurrency=2097152
+          elif [ "$libname" = geometry -o "$libname" = graph_parallel -o "$libname" = intrusive -o "$libname" = msm -o "$libname" = range -o "$libname" = spirit -o "$libname" = xpressive ]; then
+            memory_per_concurrency=1048576
+          else
+            memory_per_concurrency=524288
+          fi
+          get_clamped_concurrency $concurrency $memory_per_concurrency || concurrency=$?
+          ( cd "$testdir" && ../../../b2 -d+2 -j$concurrency $(OPTIONS) ) || true
+        fi
+      fi
+    done
+  fi
 
   ( cd '$(BOOST_ROOT)' && rm -r bin.v2 )
 

--- a/bootstrap
+++ b/bootstrap
@@ -42,6 +42,8 @@ args=`getopt                    \
       -l 'enable-openmpi::'     \
       -l 'with-mpi-backend:'    \
       -l 'enable-boost::'       \
+      -l 'with-boost-check::'   \
+      -l 'without-boost-check'  \
       -l 'enable-clang::'       \
       -l 'enable-valgrind::'    \
       -l 'concurrency:'         \
@@ -72,6 +74,7 @@ icu4c=
 openmpi=
 mpi_backend=
 boost=
+boost_check=yes
 clang=
 valgrind=
 concurrency=1
@@ -163,6 +166,12 @@ for arg in "${args[@]}"; do
       ;;
     --enable-boost)
       prev_arg=--enable-boost
+      ;;
+    --with-boost-check)
+      prev_arg=--with-boost-check
+      ;;
+    --without-boost-check)
+      boost_check=no
       ;;
     --enable-clang)
       prev_arg=--enable-clang
@@ -353,6 +362,27 @@ for arg in "${args[@]}"; do
         boost="$arg"
       fi
       ;;
+    --with-boost-check)
+      case "$arg" in
+      '')
+        boost_check=yes
+        ;;
+      yes)
+        boost_check=yes
+        ;;
+      no)
+        boost_check=no
+        ;;
+      *)
+        echo "bootstrap: option \`--with-boost-check' doesn't allow argument \`$arg'" >&2
+        exit 1
+        ;;
+      esac
+      ;;
+    --without-boost-check)
+      echo "bootstrap: an internal error" >&2
+      exit 1
+      ;;
     --enable-clang)
       if [ -z "$arg" ]; then
         clang=latest
@@ -491,6 +521,19 @@ fi
 if [ -n "$boost" ]; then
   delegated_opts=("${delegated_opts[@]}" --enable-boost="$boost")
 fi
+
+case "$boost_check" in
+yes)
+  delegated_opts=("${delegated_opts[@]}" --with-boost-check)
+  ;;
+no)
+  delegated_opts=("${delegated_opts[@]}" --without-boost-check)
+  ;;
+*)
+  echo "bootstrap: an internal error" >&2
+  exit 1
+  ;;
+esac
 
 if [ -n "$clang" ]; then
   delegated_opts=("${delegated_opts[@]}" --enable-clang="$clang")

--- a/jamroot
+++ b/jamroot
@@ -699,6 +699,56 @@ else {
 }
 
 
+local boost-check = [ option.get with-boost-check : UNSPECIFIED : IMPLIED ] ;
+switch "$(boost-check)" {
+case UNSPECIFIED :
+  boost-check = [ option.get without-boost-check : UNSPECIFIED : IMPLIED ] ;
+  switch "$(boost-check)" {
+  case UNSPECIFIED :
+    boost-check = yes ;
+  case IMPLIED :
+    boost-check = no ;
+  case * :
+    errors.error "`--without-boost-check' cannot have any value." ;
+  }
+case IMPLIED :
+  boost-check = [ option.get without-boost-check : UNSPECIFIED : IMPLIED ] ;
+  switch "$(boost-check)" {
+  case UNSPECIFIED :
+    boost-check = yes ;
+  case IMPLIED :
+    errors.error "`--with-boost-check' and `--without-boost-check' cannot be specified simultaneously." ;
+  case * :
+    errors.error "`--without-boost-check' cannot have any value." ;
+  }
+case yes :
+  boost-check = [ option.get without-boost-check : UNSPECIFIED : IMPLIED ] ;
+  switch "$(boost-check)" {
+  case UNSPECIFIED :
+    boost-check = yes ;
+  case IMPLIED :
+    errors.error "`--with-boost-check' and `--without-boost-check' cannot be specified simultaneously." ;
+  case * :
+    errors.error "`--without-boost-check' cannot have any value." ;
+  }
+case no :
+  boost-check = [ option.get without-boost-check : UNSPECIFIED : IMPLIED ] ;
+  switch "$(boost-check)" {
+  case UNSPECIFIED :
+    boost-check = no ;
+  case IMPLIED :
+    errors.error "`--with-boost-check' and `--without-boost-check' cannot be specified simultaneously." ;
+  case * :
+    errors.error "`--without-boost-check' cannot have any value." ;
+  }
+case "" :
+  errors.error "the value for `--with-boost-check' is an empty string." ;
+case * :
+  errors.error "an invalid value `$(boost-check)' is specified for `--with-boost-check'." ;
+}
+ECHO boost-check... $(boost-check) ;
+
+
 local clang = [ option.get "enable-clang" : : "latest" ] ;
 if "$(clang)" = "latest" {
   clang = [ get-clang-latest-version ] ;
@@ -954,6 +1004,9 @@ if $(boost-versions) {
   constant BOOST_VERSIONS : $(boost-versions) ;
   ECHO BOOST_VERSIONS... $(BOOST_VERSIONS:J=,) ;
 }
+
+constant BOOST_CHECK : "$(boost-check)" ;
+ECHO BOOST_CHECK... $(BOOST_CHECK) ;
 
 if "$(clang)" {
   constant CLANG : "$(clang)" ;


### PR DESCRIPTION
- bootstrap: Added support of `--with-boost-check` and
  `--without-boost-check` options.
- jamroot:
  - Added support of `--with-boost-check` and `--without-boost-check`
    options.
  - Added the definition of `BOOST_CHECK` global constant.
- boost/jamfile: Tells the build script to skip Boost unit tests when
  `BOOST_CHECK` is set as other than `yes`.
