### PR TITLE
Added support of OpenCV.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /lcov-*/
 /gcovr-*/
 /gdb-*/
+/opencv-*.tar.gz
+/opencv-*.tar.bz2
+/opencv-*/
 /gmp-*.tar.gz
 /gmp-*.tar.bz2
 /gmp-*/

--- a/bootstrap
+++ b/bootstrap
@@ -33,6 +33,7 @@ args=`getopt                    \
       -l 'enable-lcov::'        \
       -l 'enable-gcovr::'       \
       -l 'enable-gdb::'         \
+      -l 'enable-opencv::'      \
       -l 'enable-gmp::'         \
       -l 'enable-mpfr::'        \
       -l 'enable-mpc::'         \
@@ -66,6 +67,7 @@ gcc_check=yes
 lcov=
 gcovr=
 gdb=
+opencv=
 gmp=
 mpfr=
 mpc=
@@ -141,6 +143,9 @@ for arg in "${args[@]}"; do
       ;;
     --enable-gdb)
       prev_arg=--enable-gdb
+      ;;
+    --enable-opencv)
+      prev_arg=--enable-opencv
       ;;
     --enable-gmp)
       prev_arg=--enable-gmp
@@ -302,6 +307,13 @@ for arg in "${args[@]}"; do
         gdb=latest
       else
         gdb="$arg"
+      fi
+      ;;
+    --enable-opencv)
+      if [ -z "$arg" ]; then
+        opencv=latest
+      else
+        opencv="$arg"
       fi
       ;;
     --enable-gmp)
@@ -496,6 +508,10 @@ fi
 
 if [ -n "$gdb" ]; then
   delegated_opts=("${delegated_opts[@]}" --enable-gdb="$gdb")
+fi
+
+if [ -n "$opencv" ]; then
+  delegated_opts=("${delegated_opts[@]}" --enable-opencv="$opencv")
 fi
 
 if [ -n "$gmp" ]; then

--- a/jamroot
+++ b/jamroot
@@ -24,6 +24,7 @@ local .binutils-latest ;
 local .lcov-latest ;
 local .gcovr-latest ;
 local .gdb-latest ;
+local .opencv-latest ;
 local .gmp-latest ;
 local .mpfr-latest ;
 local .mpc-latest ;
@@ -88,6 +89,17 @@ local rule get-gdb-latest-version ( )
     }
   }
   return "$(.gdb-latest)" ;
+}
+
+local rule get-opencv-latest-version ( )
+{
+  if ! "$(.opencv-latest)" {
+    .opencv-latest = [ SHELL "'$(INTRO_ROOT_DIR)/opencv/latest.sh' || echo -n error" ] ;
+    if "$(.opencv-latest)" = "error" {
+      errors.error "failed to extract OpenCV latest version." ;
+    }
+  }
+  return "$(.opencv-latest)" ;
 }
 
 local rule get-gmp-latest-version ( )
@@ -193,6 +205,7 @@ local rule get-valgrind-latest-version ( )
 
 local binutils ;
 local compilers ;
+local opencv-versions ;
 local gmp-versions ;
 local mpfr-versions ;
 local mpc-versions ;
@@ -515,6 +528,21 @@ if "$(gdb)" {
     errors.error "an invalid value `$(gdb)' for `--enable-gdb'." ;
   }
   ECHO gdb... $(gdb) ;
+}
+
+
+local opencv = [ option.get "enable-opencv" : : "latest" ] ;
+if "$(opencv)" = "latest" {
+  opencv = [ get-opencv-latest-version ] ;
+}
+if "$(opencv)" {
+  if ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)?)$" : "$(opencv)" : 1 ] {
+    errors.error "an invalid value `$(opencv)' for `--enable-opencv'." ;
+  }
+  if ! "$(opencv)" in $(opencv-versions) {
+    opencv-versions += "$(opencv)" ;
+  }
+  ECHO opencv... $(opencv) ;
 }
 
 
@@ -975,6 +1003,11 @@ else {
   ECHO "GCOVR... N/A" ;
 }
 
+if $(opencv-versions) {
+  constant OPENCV_VERSIONS : $(opencv-versions) ;
+  ECHO OPENCV_VERSIONS... $(OPENCV_VERSIONS:J=,) ;
+}
+
 if $(gmp-versions) {
   constant GMP_VERSIONS : $(gmp-versions) ;
   ECHO GMP_VERSIONS... $(GMP_VERSIONS:J=,) ;
@@ -1192,6 +1225,16 @@ feature gdb-hidden : [ feature.values <gdb> ] : propagated incidental ;
   constant USE_GDB : $(use-gdb) ;
 }
 
+feature opencv        : unspecified $(opencv-versions) :                       ;
+feature opencv-hidden : [ feature.values <opencv> ]    : propagated incidental ;
+{
+  local use-opencv ;
+  for local val in [ feature.values <opencv> ] {
+    use-opencv += <opencv-hidden>$(val):<opencv>$(val) ;
+  }
+  constant USE_OPENCV : $(use-opencv) ;
+}
+
 feature gmp        : unspecified $(gmp-versions) :                       ;
 feature gmp-hidden : [ feature.values <gmp> ]    : propagated incidental ;
 {
@@ -1330,6 +1373,9 @@ for local enabled-compiler in $(enabled-compilers) {
   if "$(gdb)" {
     srcs += gdb//install ;
   }
+  if "$(opencv)" {
+    srcs += "opencv//install" ;
+  }
   if "$(gmp)" {
     srcs += "gmp//install" ;
   }
@@ -1381,6 +1427,7 @@ for local enabled-compiler in $(enabled-compilers) {
         <lcov-hidden>$(lcov)
         <gcovr-hidden>$(gcovr)
         <gdb-hidden>$(gdb)
+        <opencv-hidden>$(opencv)
         <gmp-hidden>$(gmp)
         <mpfr-hidden>$(mpfr)
         <mpc-hidden>$(mpc)
@@ -1410,6 +1457,7 @@ for local enabled-compiler in $(enabled-compilers) {
             <lcov-hidden>$(lcov)
             <gcovr-hidden>$(gcovr)
             <gdb-hidden>$(gdb)
+            <opencv-hidden>$(opencv)
             <gmp-hidden>$(gmp)
             <mpfr-hidden>$(mpfr)
             <mpc-hidden>$(mpc)
@@ -1443,6 +1491,7 @@ for local enabled-compiler in $(enabled-compilers) {
         <lcov-hidden>$(lcov)
         <gcovr-hidden>$(gcovr)
         <gdb-hidden>$(gdb)
+        <opencv-hidden>$(opencv)
         <gmp-hidden>$(gmp)
         <mpfr-hidden>$(mpfr)
         <mpc-hidden>$(mpc)
@@ -1476,6 +1525,7 @@ for local enabled-compiler in $(enabled-compilers) {
         <lcov-hidden>$(lcov)
         <gcovr-hidden>$(gcovr)
         <gdb-hidden>$(gdb)
+        <opencv-hidden>$(opencv)
         <gmp-hidden>$(gmp)
         <mpfr-hidden>$(mpfr)
         <mpc-hidden>$(mpc)

--- a/opencv/jamfile
+++ b/opencv/jamfile
@@ -1,0 +1,279 @@
+project intro/opencv ;
+
+import alias ;
+import errors ;
+import feature ;
+import make ;
+import path ;
+import regex ;
+import "$(INTRO_ROOT_DIR)/compilers"
+  : is-gcc
+    is-clang
+    is-icc
+    get-full-prefix
+    get-cc
+    get-cflags
+    get-cxx
+    get-cxxflags
+    get-environment-commands
+    get-property-dump-commands
+  ;
+
+.here = [ regex.match "Jamfile<(.*)>" : "$(__name__)" : 1 ] ;
+.here = [ path.make "$(.here)" ] ;
+.here-relative = [ path.relative "$(.here)" "$(INTRO_ROOT_DIR)" ] ;
+
+
+rule compiler-dep-req ( properties * )
+{
+  local compiler = [ feature.get-values <compiler-hidden> : $(properties) ] ;
+  local result ;
+  if [ is-gcc "$(compiler)" ] {
+    result += "<source>../gcc//install" ;
+  }
+  else if [ is-clang "$(compiler)" ] {
+    result += "<source>../gcc//install" ;
+    result += "<source>../clang//install" ;
+  }
+  else if [ is-icc "$(compiler)" ] {
+    result += "<source>../gcc//install" ;
+    result += "<source>../icc//install" ;
+  }
+  else {
+    errors.error "an internal error." ;
+  }
+  return $(result) ;
+}
+
+alias compiler-dep : : <conditional>@compiler-dep-req ;
+explicit compiler-dep ;
+
+
+for local version in $(OPENCV_VERSIONS) {
+  make "$(INTRO_ROOT_DIR)/opencv-$(version).tar.gz" : : @download ;
+  explicit "$(INTRO_ROOT_DIR)/opencv-$(version).tar.gz" ;
+}
+
+rule download ( targets * : sources * : properties * )
+{
+  HERE on $(targets) = [ path.native "$(.here)" ] ;
+  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
+  local version = [ feature.get-values <opencv-hidden> : $(properties) ] ;
+  URLS on $(targets)  = http://downloads.sourceforge.net/project/opencvlibrary/opencv-unix/$(version)/opencv-$(version).tar.gz ;
+  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
+}
+actions download
+{
+  bash -s << 'EOS'
+  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
+$(PROPERTY_DUMP_COMMANDS)
+  LINENO_ADJ=`grep -Fn 0de2af48-3edb-4680-8d70-9ba8b1c9840c '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
+  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
+  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
+  set -ex
+  rm -f '$(<)'
+  trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
+  for url in $(URLS) ; do
+    ( cd '$(<:D)' && wget -- "$url" ) && break
+  done
+  [ -f '$(<)' ]
+EOS
+}
+
+
+for local version in $(OPENCV_VERSIONS) {
+  # Use `README' file as a target representing the completion of
+  # decompression action. It is suitable for the purpose because of the
+  # following reasons;
+  #
+  #   - The name of this file is considered stable even if the version
+  #     changes.
+  #   - This file won't be modified during the build procedure.
+  #
+  make "$(INTRO_ROOT_DIR)/opencv-$(version)/README"
+    : "$(INTRO_ROOT_DIR)/opencv-$(version).tar.gz"
+    : @expand
+    ;
+  explicit "$(INTRO_ROOT_DIR)/opencv-$(version)/README" ;
+}
+
+rule expand ( targets * : sources * : properties * )
+{
+  HERE on $(targets) = [ path.native "$(.here)" ] ;
+  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
+  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
+}
+actions expand
+{
+  bash -s << 'EOS'
+  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
+$(PROPERTY_DUMP_COMMANDS)
+  LINENO_ADJ=`grep -Fn 9a196cbf-4372-4163-8f70-ac9951952722 '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
+  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
+  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
+  set -ex
+  rm -rf '$(<:D)'
+  [ -f '$(>)' ]
+  trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
+  tar xzvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  # If the timestamp of the tarball's contents is restored, the modification
+  # time of the source directory could be older than the one of the tarball.
+  # Such behavior is not desirable because the decompression always happens.
+  # Therefore, `touch' is required.
+  touch --no-create '$(<)'
+  [ -f '$(<)' ]
+EOS
+}
+
+
+rule srcdir-req ( properties * )
+{
+  local version = [ feature.get-values <opencv-hidden> : $(properties) ] ;
+  return "<source>$(INTRO_ROOT_DIR)/opencv-$(version)/README/$(DEFAULT_PROPERTIES)" ;
+}
+
+alias srcdir : : <conditional>@srcdir-req ;
+explicit srcdir ;
+
+
+rule location-conditional ( properties * )
+{
+  local full-prefix = [ get-full-prefix "$(PREFIX)" : $(properties) ] ;
+  local includedir = "$(full-prefix)/include" ;
+  return "<location>$(includedir)" ;
+}
+
+make opencv2/core/core.hpp
+  : compiler-dep
+    srcdir
+  : @make-install
+  : $(USE_COMPILER)
+    $(USE_MULTITARGET)
+    $(USE_OPENCV)
+    <conditional>@location-conditional
+  ;
+explicit opencv2/core/core.hpp ;
+
+rule make-install ( targets * : sources * : properties * )
+{
+  HERE on $(targets) = [ path.native "$(.here)" ] ;
+  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
+
+  # Sets the path to the source directory.
+  local version = [ feature.get-values <opencv> : $(properties) ] ;
+  local srcdir = "$(INTRO_ROOT_DIR)/opencv-$(version)" ;
+  SRCDIR on $(targets) = [ path.native "$(srcdir)" ] ;
+
+  # Sets the path to `objdir`.
+  local objdir = "$(INTRO_ROOT_DIR)/objdir" ;
+  local objdir-native = [ path.native "$(objdir)" ] ;
+  OBJDIR on $(targets) = "$(objdir-native)" ;
+
+  OPTIONS on $(targets) = ;
+
+  # Sets `CMAKE_INSTALL_PREFIX' option for `cmake'.
+  local full-prefix = [ get-full-prefix "$(PREFIX)" : $(properties) ] ;
+  local full-prefix-native = [ path.native "$(full-prefix)" ] ;
+  OPTIONS on $(targets) += "-D CMAKE_INSTALL_PREFIX='$(full-prefix-native)'" ;
+
+  local variant = [ feature.get-values <variant> : $(properties) ] ;
+  switch "$(variant)" {
+  case "debug" :
+    OPTIONS on $(targets) += "-D CMAKE_BUILD_TYPE=DEBUG" ;
+  case "release" :
+    OPTIONS on $(targets) += "-D CMAKE_BUILD_TYPE=RELEASE" ;
+  case "profile" :
+    OPTIONS on $(targets) += "-D CMAKE_BUILD_TYPE=RELEASE" ;
+  case "" :
+    errors.error "the value for `<variant>' is empty" ;
+  case "*" :
+    errors.error "<variant>$(variant): an unknown property" ;
+  }
+
+  # Sets the link variants for `configure' script.
+  local link = [ feature.get-values <link> : $(properties) ] ;
+  switch "$(link)" {
+  case "shared" :
+    OPTIONS on $(targets) += "-D BUILD_SHARED_LIBS=ON" ;
+  case "static" :
+    OPTIONS on $(targets) += "-D BUILD_SHARED_LIBS=OFF" ;
+  case "" :
+    errors.error "the value for `<link>' is empty" ;
+  case "*" :
+    errors.error "<link>$(link): an unknown property" ;
+  }
+
+  local cc = [ get-cc "$(PREFIX)" : $(properties) ] ;
+  local cc-native = [ path.native "$(cc)" ] ;
+  OPTIONS on $(targets) += "-D CMAKE_C_COMPILER='$(cc-native)'" ;
+
+  local cflags = [ get-cflags $(properties) ] ;
+  if "$(cflags)" {
+    CFLAGS on $(targets) = "$(cflags)" ;
+    OPTIONS on $(targets) += "-D CMAKE_C_FLAGS='@$(objdir-native)/cflags'" ;
+  }
+
+  local cxx = [ get-cxx "$(PREFIX)" : $(properties) ] ;
+  local cxx-native = [ path.native "$(cxx)" ] ;
+  OPTIONS on $(targets) += "-D CMAKE_CXX_COMPILER='$(cxx-native)'" ;
+
+  local cxxflags = [ get-cxxflags $(properties) ] ;
+  if "$(cxxflags)" {
+    CXXFLAGS on $(targets) = "$(cxxflags)" ;
+    OPTIONS on $(targets) += "-D CMAKE_CXX_FLAGS='@$(objdir-native)/cxxflags'" ;
+  }
+
+  local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;
+  ENVIRONMENT_COMMANDS on $(targets) = "$(environment-commands)" ;
+
+  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
+}
+actions make-install
+{
+  bash -s << 'EOS'
+  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
+$(ENVIRONMENT_COMMANDS)
+$(PROPERTY_DUMP_COMMANDS)
+  LINENO_ADJ=`grep -Fn 537d2268-fdcb-4819-b4ad-7396a395da30 '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
+  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
+  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
+  set -ex
+
+  rm -rf '$(OBJDIR)'
+
+  cleanup ()
+  {
+    if [ -d '$(OBJDIR)' ]; then
+      mv -n '$(OBJDIR)' "$(INTRO_ROOT_DIR)/objdir_opencv_$$"
+    fi
+  }
+  trap cleanup ERR HUP INT QUIT TERM
+
+  # Creates `objdir`.
+  ( cd '$(INTRO_ROOT_DIR)' && mkdir objdir )
+
+  ( cd '$(OBJDIR)' && echo -n '$(CFLAGS)' > cflags )
+  ( cd '$(OBJDIR)' && echo -n '$(CXXFLAGS)' > cxxflags )
+
+  ( cd '$(OBJDIR)' && 'cmake' $(OPTIONS) '$(SRCDIR)' )
+
+  # Checks the creation of `Makefile`.
+  [ -f '$(OBJDIR)/Makefile' ]
+
+  ( cd '$(OBJDIR)' && make --jobs=$(CONCURRENCY) )
+
+  ( cd '$(OBJDIR)' && make --jobs=$(CONCURRENCY) opencv_tests )
+
+  ( cd '$(OBJDIR)' && make install )
+
+  # Cleans up `objdir`.
+  rm -r '$(OBJDIR)'
+
+  [ -f '$(<)' ]
+  touch --no-create '$(<)'
+EOS
+}
+
+
+alias install : opencv2/core/core.hpp ;
+explicit install ;

--- a/opencv/latest.sh
+++ b/opencv/latest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+intro_root_dir=`(cd \`dirname "$0"\`; cd ..; pwd)`
+grep -Fq 5fa94497-1c30-4bdf-a2d6-43ade94e55db "$intro_root_dir/opencv/latest.sh"
+
+urls=('http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/')
+timeout=30
+
+tempdir=`mktemp -d`
+trap 'rm -rf "$tempdir"' ERR HUP INT TERM QUIT
+
+for url in "${urls[@]}"; do
+  curl -m $timeout -o `mktemp --tmpdir="$tempdir"` -s "$url" &
+done
+wait
+
+versions=`cat "$tempdir"/*`
+rm -r "$tempdir"
+if echo "$versions" | grep -Eq '/projects/opencvlibrary/files/opencv-unix/[[:digit:]]+(\.[[:digit:]]+){0,3}/'; then
+  versions=`echo "$versions" | grep -Eo '/projects/opencvlibrary/files/opencv-unix/[[:digit:]]+(\.[[:digit:]]+){0,3}/'`
+  versions=`echo "$versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,3}'`
+fi
+
+local_versions=`cd "$intro_root_dir" && ls -1 opencv-*/README 2>/dev/null || true`
+if echo "$local_versions" | grep -Eq '^opencv-[[:digit:]]+(\.[[:digit:]]+){0,3}/README$'; then
+  local_versions=`echo "$local_versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,3}'`
+  versions=`echo -e ${versions:+"$versions"'\n'}"$local_versions"`
+fi
+
+[ -n "$versions" ]
+versions=`echo "$versions" | sort -u -t . -k 1,1n -k 2,2n -k 3,3n -k 4,4n`
+latest_version=`echo "$versions" | tail -n 1`
+echo -n $latest_version


### PR DESCRIPTION
- .gitignore: Told to ignore `opencv-*` directory and tarballs.
- bootstrap: Added support of `--enable-opencv`.
- jamroot:
  - Added handling of `--enable-opencv`.
  - Added `<opencv>` and `<opencv-hidden>` features.
- opencv/latest.sh: New. Added script to extract the latest version of
  OpenCV.
- opencv/jamfile: New. Added build script of OpenCV.
