### PR TITLE
Added support for Binutils trunk.

### DIFF
--- a/binutils/checkout.sh
+++ b/binutils/checkout.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+PS4='+binutils/checkout.sh:$LINENO: '
+set -ex
+
+intro_root_dir=`(cd \`dirname "$0"\`; cd ..; pwd)`
+grep -Fq 5f91cd3a-6dac-42fe-bfbb-fe637ee880a4 "$intro_root_dir/binutils/checkout.sh"
+
+[ $# -eq 0 ]
+
+if [ -e "$intro_root_dir/binutils-trunk" ]; then
+  [ -d "$intro_root_dir/binutils-trunk/.git" ]
+  ( cd "$intro_root_dir/binutils-trunk" && git clean -ffdx )
+fi
+
+cleanup ()
+{
+  rm -rf "$intro_root_dir/binutils-trunk"
+}
+trap cleanup ERR HUP INT QUIT TERM
+
+if [ '!' -e "$intro_root_dir/binutils-trunk" ]; then
+  ( cd "$intro_root_dir" && git clone 'git://sourceware.org/git/binutils-gdb.git' binutils-trunk )
+fi
+
+[ -d "$intro_root_dir/binutils-trunk/.git" ]
+
+( cd "$intro_root_dir/binutils-trunk" && git pull --ff-only )
+
+timestamp="$intro_root_dir/binutils-trunk/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5"
+
+last_commit_date=`cd "$intro_root_dir/binutils-trunk" && LANG=C git log -1 --date=iso | grep -E '^Date:' | sed -e 's/^Date:[[:space:]]*\(.*\)$/\1/'`
+find "$intro_root_dir/binutils-trunk" -execdir touch --date="$last_commit_date" '{}' \+
+touch --date="$last_commit_date" "$timestamp"

--- a/binutils/download.sh
+++ b/binutils/download.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+PS4='+binutils/download.sh:$LINENO: '
+set -ex
+
+intro_root_dir=`(cd \`dirname "$0"\`; cd ..; pwd)`
+grep -Fq 36c08c27-a111-466d-858d-848c134305a4 "$intro_root_dir/binutils/download.sh"
+
+[ $# -eq 1 ]
+
+version="$1"
+if [ "$version" = latest ]; then
+  version=`"$intro_root_dir/binutils/latest.sh"`
+fi
+if echo "$version" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'; then
+  :
+else
+  exit 1
+fi
+
+[ '!' -e "$intro_root_dir/binutils-${version}.tar.bz2.bak" ]
+if [ -e "$intro_root_dir/binutils-${version}.tar.bz2" ]; then
+  mv "$intro_root_dir/binutils-${version}.tar.bz2" "$intro_root_dir/binutils-${version}.tar.bz2.bak"
+fi
+
+[ '!' -e "$intro_root_dir/binutils-${version}.bak" ]
+if [ -e "$intro_root_dir/binutils-${version}" ]; then
+  mv "$intro_root_dir/binutils-${version}" "$intro_root_dir/binutils-${version}.bak"
+fi
+
+cleanup ()
+{
+  rm -f "$intro_root_dir/binutils-${version}.tar.bz2"
+  rm -rf "$intro_root_dir/binutils-${version}"
+  if [ -e "$intro_root_dir/binutils-${version}.tar.bz2.bak" ]; then
+    mv "$intro_root_dir/binutils-${version}.tar.bz2.bak" "$intro_root_dir/binutils-${version}.tar.bz2"
+  fi
+  if [ -e "$intro_root_dir/binutils-${version}.bak" ]; then
+    mv "$intro_root_dir/binutils-${version}.bak" "$intro_root_dir/binutils-${version}"
+  fi
+}
+trap cleanup ERR HUP INT QUIT TERM
+
+tarball=
+if [ -e "$intro_root_dir/binutils-${version}.tar.bz2.bak" ]; then
+  [ -f "$intro_root_dir/binutils-${version}.tar.bz2.bak" ]
+  tarball="$intro_root_dir/binutils-${version}.tar.bz2.bak"
+else
+  urls=("http://ftp.jaist.ac.jp/pub/GNU/binutils/binutils-${version}.tar.bz2"
+        "http://ftp.nara.wide.ad.jp/pub/GNU/gnu/binutils/binutils-${version}.tar.bz2"
+        "http://ftp.tsukuba.wide.ad.jp/software/binutils/binutils-${version}.tar.bz2"
+        "http://www.ring.gr.jp/archives/GNU/binutils/binutils-${version}.tar.bz2"
+        "ftp://sourceware.org/pub/binutils/snapshots/binutils-${version}.tar.bz2")
+  for url in "${urls[@]}"; do
+    ( cd "$intro_root_dir" && wget --quiet -- "$url" ) && break
+  done
+  tarball="$intro_root_dir/binutils-${version}.tar.bz2"
+fi
+
+[ -f "$intro_root_dir/binutils-${version}.tar.bz2.bak" -o -f "$intro_root_dir/binutils-${version}.tar.bz2" ]
+[ '!' '(' -f "$intro_root_dir/binutils-${version}.tar.bz2.bak" -a -f "$intro_root_dir/binutils-${version}.tar.bz2" ')' ]
+[ -f "$tarball" ]
+
+old_timestamp="$intro_root_dir/binutils-${version}.bak/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5"
+
+srcdir=
+if [ -e "$old_timestamp" ]; then
+  [ -f "$old_timestamp" ]
+  if [ "$tarball" -nt "$old_timestamp" ]; then
+    tar -xjf "$tarball" --directory="$intro_root_dir"
+    srcdir="$intro_root_dir/binutils-${version}"
+  else
+    srcdir="$intro_root_dir/binutils-${version}.bak"
+  fi
+else
+  tar -xjf "$tarball" --directory="$intro_root_dir"
+  srcdir="$intro_root_dir/binutils-${version}"
+fi
+
+[ -d "$srcdir" ]
+
+timestamp="$srcdir/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5"
+
+if [ -e "$timestamp" ]; then
+  [ "$srcdir" = "$intro_root_dir/binutils-${version}.bak" ]
+  [ -f "$timestamp" ]
+  [ '!' "$tarball" -nt "$timestamp" ]
+else
+  [ "$srcdir" = "$intro_root_dir/binutils-${version}" ]
+  touch "$timestamp"
+  find "$srcdir" -newer "$tarball" -execdir touch --reference="$tarball" '{}' '+'
+  find "$srcdir" -print0 | xargs -0 -L 1 bash -c '[ "$1" -ot "$0" ] && touch --reference="$1" "$0"; true' "$timestamp"
+  find "$srcdir" -print0 | xargs -0 -L 1 bash -c '[ "$1" -nt "$0" ] && touch --reference="$1" "$0"; true' "$timestamp"
+fi
+
+if [ "$tarball" = "$intro_root_dir/binutils-${version}.tar.bz2.bak" ]; then
+  [ '!' -e "$intro_root_dir/binutils-${version}.tar.bz2" ]
+  mv "$intro_root_dir/binutils-${version}.tar.bz2.bak" "$intro_root_dir/binutils-${version}.tar.bz2"
+fi
+
+if [ "$srcdir" = "$intro_root_dir/binutils-${version}.bak" ]; then
+  [ '!' -e "$intro_root_dir/binutils-${version}" ]
+  mv "$intro_root_dir/binutils-${version}.bak" "$intro_root_dir/binutils-${version}"
+fi
+
+if [ -e "$intro_root_dir/binutils-${version}.tar.bz2.bak" ]; then
+  rm -f "$intro_root_dir/binutils-${version}.tar.bz2.bak"
+fi
+
+if [ -e "$intro_root_dir/binutils-${version}.bak" ]; then
+  rm -rf "$intro_root_dir/binutils-${version}.bak"
+fi

--- a/binutils/jamfile
+++ b/binutils/jamfile
@@ -50,93 +50,6 @@ alias compiler-dep : : <conditional>@compiler-dep-req ;
 explicit compiler-dep ;
 
 
-make "$(INTRO_ROOT_DIR)/binutils-$(BINUTILS).tar.bz2" : : @download ;
-explicit "$(INTRO_ROOT_DIR)/binutils-$(BINUTILS).tar.bz2" ;
-
-rule download ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  local version = [ feature.get-values <binutils-hidden> : $(properties) ] ;
-  URLS on $(targets)  = "'http://ftp.nara.wide.ad.jp/pub/GNU/gnu/binutils/binutils-$(version).tar.bz2'" ;
-  URLS on $(targets) += "'http://ftp.tsukuba.wide.ad.jp/software/binutils/binutils-$(version).tar.bz2'" ;
-  URLS on $(targets) += "'http://ftp.jaist.ac.jp/pub/GNU/binutils/binutils-$(version).tar.bz2'" ;
-  URLS on $(targets) += "'ftp://sourceware.org/pub/binutils/snapshots/binutils-$(version).tar.bz2'" ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions download
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn c3a35fdf-555a-4787-acac-35219af0b4c3 '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -f '$(<)'
-  trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  for url in $(URLS) ; do
-    ( cd '$(<:D)' && wget -- "$url" ) && break
-  done
-  [ -f '$(<)' ]
-EOS
-}
-
-
-# Use `README' file as a target representing the completion of
-# decompression action. It is suitable for the purpose because of the
-# following reasons;
-#
-#   - The name of this file is considered stable even if the version
-#     changes.
-#   - This file won't be modified during the build procedure.
-#
-make "$(INTRO_ROOT_DIR)/binutils-$(BINUTILS)/README"
-  : "$(INTRO_ROOT_DIR)/binutils-$(BINUTILS).tar.bz2"
-  : @expand
-  ;
-explicit "$(INTRO_ROOT_DIR)/binutils-$(BINUTILS)/README" ;
-
-rule expand ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions expand
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn 3909aa43-2c54-4244-b8c0-61c59512ca57 '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -rf '$(<:D)'
-  [ -f '$(>)' ]
-  trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
-  # If the timestamp of the tarball's contents is restored, the modification
-  # time of the source directory could be older than the one of the tarball.
-  # Such behavior is not desirable because the decompression always happens.
-  # Therefore, `touch' is required.
-  touch --no-create '$(<)'
-  [ -f '$(<)' ]
-EOS
-}
-
-
-rule srcdir-req ( properties * )
-{
-  local version = [ feature.get-values <binutils-hidden> : $(properties) ] ;
-  return "<source>$(INTRO_ROOT_DIR)/binutils-$(version)/README/$(DEFAULT_PROPERTIES)" ;
-}
-
-alias srcdir : : <conditional>@srcdir-req ;
-explicit srcdir ;
-
-
-
 rule location-conditional ( properties * )
 {
   local bindir = [ get-default-bindir "$(PREFIX)" : $(properties) ] ;
@@ -145,7 +58,7 @@ rule location-conditional ( properties * )
 
 make ld.gold
   : compiler-dep
-    srcdir
+    "$(INTRO_ROOT_DIR)/binutils-$(BINUTILS)/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5"
   : @make-install
   : <conditional>@location-conditional
     $(USE_COMPILER)

--- a/bootstrap
+++ b/bootstrap
@@ -582,6 +582,19 @@ fi
 
 intro_root=`(cd \`dirname "$0"\`; pwd)`
 
+if [ "$binutils" = latest ]; then
+  "$intro_root/binutils/download.sh" latest
+elif echo "$binutils" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'; then
+  "$intro_root/binutils/download.sh" "$binutils"
+elif [ "$binutils" = trunk ]; then
+  "$intro_root/binutils/checkout.sh"
+elif [ "$binutils" != system ]; then
+  :
+else
+  echo "error: an invalid value \`$binutils' for \`--with-binutils'." >&2
+  exit 1
+fi
+
 boost_latest=`"$intro_root/boost/latest.sh"`
 
 if [ ! -d "$prefix/boost/$boost_latest" ]; then

--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -159,7 +159,7 @@ rule gxx-wrapper-conditional ( properties * )
 
   local result ;
   if "$(binutils)" != "unspecified" {
-    result += "<source>../binutils//srcdir" ;
+    result += "<source>$(INTRO_ROOT_DIR)/binutils-$(binutils)/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5" ;
   }
   if "$(gmp)" != "unspecified" {
     result += "<source>../gmp//srcdir/<gmp-hidden>$(gmp)" ;

--- a/jamroot
+++ b/jamroot
@@ -223,14 +223,23 @@ if ! "$(prefix)" {
 ECHO prefix... $(prefix) ;
 
 
-binutils = [ option.get "with-binutils" : "system" : "IMPLIED" ] ;
-if "$(binutils)" = "IMPLIED" {
+binutils = [ option.get with-binutils : system : IMPLIED ] ;
+if "$(binutils)" = IMPLIED {
   errors.error "no value specified for `--with-binutils'." ;
 }
-if "$(binutils)" = "latest" {
+if "$(binutils)" = latest {
   binutils = [ get-binutils-latest-version ] ;
 }
-if "$(binutils)" != "system" && ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(binutils)" : 1 ] {
+if "$(binutils)" = system {
+  # Do nothing.
+}
+else if "$(binutils)" = trunk {
+  # Do nothing.
+}
+else if [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(binutils)" : 1 ] {
+  # Do nothing.
+}
+else {
   errors.error "an invalid value `$(binutils)' for `--with-binutils'." ;
 }
 ECHO binutils... $(binutils) ;
@@ -818,8 +827,7 @@ if "$(clang)" {
   else if "$(clang)" = "trunk" {
     # Do nothing.
   }
-  else
-  {
+  else {
     errors.error "an invalid value `$(clang)' for `--enable-clang' option.\n" ;
   }
   ECHO clang... $(clang) ;


### PR DESCRIPTION
Removed downloading and expanding actions from build procedure. These
actions now run before build procedure is invoked.
- bootstrap: Changed to invoke downloading/expanding or cloning scripts.
- download.sh: Newly added.
- checkout.sh: Newly added.
- jamroot: Added support for `trunk` argument of `with-binutils` option.
- binutils/jamfile: Removed downloading and expanding actions.
- gcc/jamfile: Added dependency on the timestamp file of Binutils source
  tree to GCC build target.
