### PR TITLE
Fixed #67.

### DIFF
--- a/binutils/download.sh
+++ b/binutils/download.sh
@@ -9,9 +9,6 @@ grep -Fq 36c08c27-a111-466d-858d-848c134305a4 "$intro_root_dir/binutils/download
 [ $# -eq 1 ]
 
 version="$1"
-if [ "$version" = latest ]; then
-  version=`"$intro_root_dir/binutils/latest.sh"`
-fi
 if echo "$version" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'; then
   :
 else

--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+intro_root=`(cd \`dirname "$0"\`; pwd)`
+grep -Fq 434daa2b-b9b0-498c-bd86-18404f1c3464 "$intro_root/jamroot"
+
 # Test if `optget' is an enhanced version or an old version.
 if getopt --test 2>&1 | grep -Fq -- '--'; then
   echo "bootstrap: requires and enhanced version of \`getopt'" >&2
@@ -438,8 +441,22 @@ for arg in "${args[@]}"; do
   fi
 done
 
+
 delegated_opts=("${delegated_opts[@]}" --prefix="$prefix")
 
+if [ "$binutils" = latest ]; then
+  binutils=`"$intro_root/binutils/latest.sh"`
+fi
+if echo "$binutils" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'; then
+  "$intro_root/binutils/download.sh" "$binutils"
+elif [ "$binutils" = trunk ]; then
+  "$intro_root/binutils/checkout.sh"
+elif [ "$binutils" = system ]; then
+  :
+else
+  echo "error: an invalid value \`$binutils' for \`--with-binutils'." >&2
+  exit 1
+fi
 delegated_opts=("${delegated_opts[@]}" --with-binutils="$binutils")
 
 delegated_opts=("${delegated_opts[@]}" --with-gmp-for-gcc="$gmp_for_gcc")
@@ -579,21 +596,6 @@ if [ -n "$concurrency" ]; then
   delegated_opts=("${delegated_opts[@]}" --concurrency=$concurrency)
 fi
 
-
-intro_root=`(cd \`dirname "$0"\`; pwd)`
-
-if [ "$binutils" = latest ]; then
-  "$intro_root/binutils/download.sh" latest
-elif echo "$binutils" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'; then
-  "$intro_root/binutils/download.sh" "$binutils"
-elif [ "$binutils" = trunk ]; then
-  "$intro_root/binutils/checkout.sh"
-elif [ "$binutils" != system ]; then
-  :
-else
-  echo "error: an invalid value \`$binutils' for \`--with-binutils'." >&2
-  exit 1
-fi
 
 boost_latest=`"$intro_root/boost/latest.sh"`
 

--- a/jamroot
+++ b/jamroot
@@ -20,7 +20,6 @@ import "$(INTRO_ROOT_DIR)/compilers"
 "$(INTRO_ROOT_DIR)/compilers.init" "$(INTRO_ROOT_DIR)" ;
 
 
-local .binutils-latest ;
 local .lcov-latest ;
 local .gcovr-latest ;
 local .gdb-latest ;
@@ -45,17 +44,6 @@ local rule get-boost-latest-version ( )
     }
   }
   return "$(.boost-latest)" ;
-}
-
-local rule get-binutils-latest-version ( )
-{
-  if ! "$(.binutils-latest)" {
-    .binutils-latest = [ SHELL "'$(INTRO_ROOT_DIR)/binutils/latest.sh' || echo -n error" ] ;
-    if "$(.binutils-latest)" = "error" {
-      errors.error "failed to extract binutils latest version." ;
-    }
-  }
-  return "$(.binutils-latest)" ;
 }
 
 local rule get-lcov-latest-version ( )
@@ -226,9 +214,6 @@ ECHO prefix... $(prefix) ;
 binutils = [ option.get with-binutils : system : IMPLIED ] ;
 if "$(binutils)" = IMPLIED {
   errors.error "no value specified for `--with-binutils'." ;
-}
-if "$(binutils)" = latest {
-  binutils = [ get-binutils-latest-version ] ;
 }
 if "$(binutils)" = system {
   # Do nothing.


### PR DESCRIPTION
- bootstrap: Changed to dereference `latest` value of `--with-binutils`
  command-line option into a concrete version number before invoking `bjam`.
- jamroot: Removed support for `latest` value of `--with-binutils`
  command-line option.
- binutils/download.sh: Removed support for `latest` value of the
  command-line argument.
