### PR TITLE
Fixed #69.

### DIFF
--- a/binutils/checkout.sh
+++ b/binutils/checkout.sh
@@ -8,27 +8,36 @@ set -ex
 
 [ $# -eq 0 ]
 
+timestamp=cd9de9b7-e312-49f1-b2a5-24cd4f322ed5
+timestamp_path="$intro_root/binutils-trunk/$timestamp"
+
 if [ -e "$intro_root/binutils-trunk" ]; then
-  [ -d "$intro_root/binutils-trunk/.git" ]
-  ( cd "$intro_root/binutils-trunk" && git clean -ffdx )
+  if [ -f "$timestamp_path" ]; then
+    ( cd "$intro_root/binutils-trunk" && [ `pwd` = `git rev-parse --show-toplevel` ] )
+    ( cd "$intro_root/binutils-trunk" && git clean -ffdx )
+  else
+    rm -r "$intro_root/binutils-trunk"
+  fi
 fi
 
 cleanup ()
 {
-  rm -rf "$intro_root/binutils-trunk"
+  if [ -e "$intro_root/binutils-trunk" ]; then
+    [ -d "$intro_root/binutils-trunk" ] || {
+      echo 'warning: a logic error in rollback process, forced to proceed' >&2;
+    }
+    rm -r "$intro_root/binutils-trunk"
+  fi
 }
 trap cleanup ERR HUP INT QUIT TERM
 
 if [ '!' -e "$intro_root/binutils-trunk" ]; then
   ( cd "$intro_root" && git clone 'git://sourceware.org/git/binutils-gdb.git' binutils-trunk )
 fi
-
-[ -d "$intro_root/binutils-trunk/.git" ]
+( cd "$intro_root/binutils-trunk" && [ `pwd` = `git rev-parse --show-toplevel` ] )
 
 ( cd "$intro_root/binutils-trunk" && git pull --ff-only )
 
-timestamp="$intro_root/binutils-trunk/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5"
-
 last_commit_date=`cd "$intro_root/binutils-trunk" && LANG=C git log -1 --date=iso | grep -E '^Date:' | sed -e 's/^Date:[[:space:]]*\(.*\)$/\1/'`
 find "$intro_root/binutils-trunk" -execdir touch --date="$last_commit_date" '{}' \+
-touch --date="$last_commit_date" "$timestamp"
+touch --date="$last_commit_date" "$timestamp_path"

--- a/bootstrap
+++ b/bootstrap
@@ -454,7 +454,7 @@ elif [ "$binutils" = trunk ]; then
 elif [ "$binutils" = system ]; then
   :
 else
-  echo "error: an invalid value \`$binutils' for \`--with-binutils'." >&2
+  echo "error: an invalid value \`$binutils' for \`--with-binutils'" >&2
   exit 1
 fi
 delegated_opts=("${delegated_opts[@]}" --with-binutils="$binutils")
@@ -467,6 +467,19 @@ delegated_opts=("${delegated_opts[@]}" --with-mpc-for-gcc="$mpc_for_gcc")
 
 delegated_opts=("${delegated_opts[@]}" --with-isl-for-gcc="$isl_for_gcc")
 
+if [ "$cloog_for_gcc" = latest ]; then
+  cloog_for_gcc=`"$intro_root/cloog/latest.sh"`
+fi
+if echo "$cloog_for_gcc" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'; then
+  "$intro_root/cloog/download.sh" "$cloog_for_gcc"
+elif [ "$cloog_for_gcc" = trunk ]; then
+  "$intro_root/cloog/checkout.sh"
+elif [ "$cloog_for_gcc" = system ]; then
+  :
+else
+  echo "error: an invalid value \`$cloog_for_gcc' for \`--with-cloog-for-gcc'" >&2
+  exit 1
+fi
 delegated_opts=("${delegated_opts[@]}" --with-cloog-for-gcc="$cloog_for_gcc")
 
 delegated_opts=("${delegated_opts[@]}" --enable-compilers="$compilers")
@@ -548,6 +561,17 @@ if [ -n "$isl" ]; then
 fi
 
 if [ -n "$cloog" ]; then
+  if [ "$cloog" = latest ]; then
+    cloog=`"$intro_root/cloog/latest.sh"`
+  fi
+  if echo "$cloog" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'; then
+    "$intro_root/cloog/download.sh" "$cloog"
+  elif [ "$cloog" = trunk ]; then
+    "$intro_root/cloog/checkout.sh"
+  else
+    echo "error: an invalid value \`$cloog' for \`--enable-cloog'" >&2
+    exit 1
+  fi
   delegated_opts=("${delegated_opts[@]}" --enable-cloog="$cloog")
 fi
 

--- a/cloog/checkout.sh
+++ b/cloog/checkout.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+intro_root=`(cd \`dirname "$0"\`; cd ..; pwd)`
+grep -Fq 5a382e76-5269-43f1-b00f-c2b14887259f "$intro_root/cloog/checkout.sh"
+
+PS4='+$0:$LINENO: '
+set -ex
+
+[ $# -eq 0 ]
+
+timestamp=528457b5-9e38-4c8f-ac97-fbdb3ccfdbe9
+timestamp_path="$intro_root/cloog-trunk/$timestamp"
+
+if [ -e "$intro_root/cloog-trunk" ]; then
+  if [ -f "$timestamp_path" ]; then
+    ( cd "$intro_root/cloog-trunk" && [ `pwd` = `git rev-parse --show-toplevel` ] )
+    ( cd "$intro_root/cloog-trunk" && git clean -ffdx )
+  else
+    rm -r "$intro_root/cloog-trunk"
+  fi
+fi
+
+cleanup ()
+{
+  if [ -e "$intro_root/cloog-trunk" ]; then
+    [ -d "$intro_root/cloog-trunk" ] || {
+      echo 'warning: a logic error in rollback process, forced to proceed' >&2;
+    }
+    rm -r "$intro_root/cloog-trunk"
+  fi
+}
+trap cleanup ERR HUP INT QUIT TERM
+
+if [ '!' -e "$intro_root/cloog-trunk" ]; then
+  ( cd "$intro_root" && git clone 'git://repo.or.cz/cloog.git' cloog-trunk )
+fi
+( cd "$intro_root/cloog-trunk" && [ `pwd` = `git rev-parse --show-toplevel` ] )
+
+( cd "$intro_root/cloog-trunk" && git pull --ff-only )
+
+( cd "$intro_root/cloog-trunk" && ./autogen.sh )
+
+last_commit_date=`cd "$intro_root/cloog-trunk" && LANG=C git log -1 --date=iso | grep -E '^Date:' | sed -e 's/^Date:[[:space:]]*\(.*\)$/\1/'`
+find "$intro_root/cloog-trunk" -execdir touch --date="$last_commit_date" '{}' \+
+touch --date="$last_commit_date" "$timestamp_path"

--- a/cloog/download.sh
+++ b/cloog/download.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+intro_root=`(cd \`dirname "$0"\`; cd ..; pwd)`
+grep -Fq 9ae5da01-d17c-4c4b-a9ec-2d77fd8e496c "$intro_root/cloog/download.sh"
+
+PS4='+$0:$LINENO: '
+set -ex
+
+[ $# -eq 1 ]
+
+version="$1"
+echo "$version" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+(\.[[:digit:]]+)?)?$'
+
+[ '!' -e "$intro_root/cloog-${version}.tar.gz.bak" ]
+if [ -e "$intro_root/cloog-${version}.tar.gz" ]; then
+  if [ -f "$intro_root/cloog-${version}.tar.gz" ]; then
+    mv "$intro_root/cloog-${version}.tar.gz" "$intro_root/cloog-${version}.tar.gz.bak"
+  else
+    rm -r "$intro_root/cloog-${version}.tar.gz"
+  fi
+fi
+[ '!' -e "$intro_root/cloog-${version}.tar.gz" ]
+
+timestamp=528457b5-9e38-4c8f-ac97-fbdb3ccfdbe9
+
+[ '!' -e "$intro_root/cloog-${version}.bak" ]
+if [ -e "$intro_root/cloog-${version}" ]; then
+  if [ -f "$intro_root/cloog-${version}/$timestamp" ]; then
+    mv "$intro_root/cloog-${version}" "$intro_root/cloog-${version}.bak"
+  else
+    rm -r "$intro_root/cloog-${version}"
+  fi
+fi
+[ '!' -e "$intro_root/cloog-${version}" ]
+
+cleanup ()
+{
+  if [ -e "$intro_root/cloog-${version}.tar.gz" ]; then
+    [ -f "$intro_root/cloog-${version}.tar.gz" ] || {
+      echo 'warning: a logic error in rollback process, forced to proceed' >&2;
+    }
+    rm -r "$intro_root/cloog-${version}.tar.gz"
+  fi
+  if [ -e "$intro_root/cloog-${version}" ]; then
+    [ -d "$intro_root/cloog-${version}" ] || {
+      echo 'warning: a logic error in rollback process, forced to proceed' >&2;
+    }
+    rm -r "$intro_root/cloog-${version}"
+  fi
+  if [ -e "$intro_root/cloog-${version}.tar.gz.bak" ]; then
+    [ -f "$intro_root/cloog-${version}.tar.gz.bak" ] || {
+      echo 'warning: a logic error in rollback process, forced to proceed' >&2;
+    }
+    mv "$intro_root/cloog-${version}.tar.gz.bak" "$intro_root/cloog-${version}.tar.gz"
+  fi
+  if [ -e "$intro_root/cloog-${version}.bak" ]; then
+    [ -f "$intro_root/cloog-${version}.bak/$timestamp" ] || {
+      echo 'warning: a logic error in rollback process, forced to proceed' >&2;
+    }
+    mv "$intro_root/cloog-${version}.bak" "$intro_root/cloog-${version}"
+  fi
+}
+trap cleanup ERR HUP INT QUIT TERM
+
+tarball=
+if [ -e "$intro_root/cloog-${version}.tar.gz.bak" ]; then
+  [ -f "$intro_root/cloog-${version}.tar.gz.bak" ]
+  tarball="$intro_root/cloog-${version}.tar.gz.bak"
+else
+  urls=("http://www.bastoul.net/cloog/pages/download/cloog-${version}.tar.gz")
+  for url in "${urls[@]}"; do
+    ( cd "$intro_root" && wget --quiet -- "$url" ) && break
+  done
+  tarball="$intro_root/cloog-${version}.tar.gz"
+fi
+[ -f "$intro_root/cloog-${version}.tar.gz.bak" -o -f "$intro_root/cloog-${version}.tar.gz" ]
+[ '!' '(' -f "$intro_root/cloog-${version}.tar.gz.bak" -a -f "$intro_root/cloog-${version}.tar.gz" ')' ]
+[ -f "$tarball" ]
+
+old_timestamp_path="$intro_root/cloog-${version}.bak/$timestamp"
+
+srcdir=
+if [ -e "$old_timestamp_path" ]; then
+  [ -f "$old_timestamp_path" ]
+  if [ "$tarball" -nt "$old_timestamp_path" ]; then
+    tar -xzf "$tarball" --directory="$intro_root"
+    srcdir="$intro_root/cloog-${version}"
+  else
+    srcdir="$intro_root/cloog-${version}.bak"
+  fi
+else
+  tar -xzf "$tarball" --directory="$intro_root"
+  srcdir="$intro_root/cloog-${version}"
+fi
+[ -d "$srcdir" ]
+
+new_timestamp_path="$srcdir/$timestamp"
+
+if [ -e "$new_timestamp_path" ]; then
+  [ "$srcdir" = "$intro_root/cloog-${version}.bak" ]
+  [ -f "$new_timestamp_path" ]
+  [ '!' "$tarball" -nt "$new_timestamp_path" ]
+else
+  [ "$srcdir" = "$intro_root/cloog-${version}" ]
+  touch "$new_timestamp_path"
+  find "$srcdir" -newer "$tarball" -execdir touch --reference="$tarball" '{}' '+'
+  find "$srcdir" -print0 | xargs -0 -L 1 bash -c '[ "$1" -ot "$0" ] && touch --reference="$1" "$0"; true' "$new_timestamp_path"
+  find "$srcdir" -print0 | xargs -0 -L 1 bash -c '[ "$1" -nt "$0" ] && touch --reference="$1" "$0"; true' "$new_timestamp_path"
+fi
+
+if [ "$tarball" = "$intro_root/cloog-${version}.tar.gz.bak" ]; then
+  [ '!' -e "$intro_root/cloog-${version}.tar.gz" ]
+  mv "$intro_root/cloog-${version}.tar.gz.bak" "$intro_root/cloog-${version}.tar.gz"
+fi
+
+if [ "$srcdir" = "$intro_root/cloog-${version}.bak" ]; then
+  [ '!' -e "$intro_root/cloog-${version}" ]
+  mv "$intro_root/cloog-${version}.bak" "$intro_root/cloog-${version}"
+fi
+
+if [ -e "$intro_root/cloog-${version}.tar.gz.bak" ]; then
+  [ -f "$intro_root/cloog-${version}.tar.gz.bak" ] || {
+    echo 'warning: a logic error in commit process, forced to proceed' >&2;
+  }
+  rm -r "$intro_root/cloog-${version}.tar.gz.bak"
+fi
+
+if [ -e "$intro_root/cloog-${version}.bak" ]; then
+  [ -d "$intro_root/cloog-${version}.bak" ] || {
+    echo 'warning: a logic error in commit process, forced to proceed' >&2;
+  }
+  rm -r "$intro_root/cloog-${version}.bak"
+fi

--- a/cloog/jamfile
+++ b/cloog/jamfile
@@ -50,135 +50,14 @@ alias compiler-dep : : <conditional>@compiler-dep-req ;
 explicit compiler-dep ;
 
 
-for local version in $(CLOOG_VERSIONS) {
-  if "$(version)" != "trunk" {
-    make "$(INTRO_ROOT_DIR)/cloog-$(version).tar.gz" : : @download ;
-    explicit "$(INTRO_ROOT_DIR)/cloog-$(version).tar.gz" ;
-  }
-}
-
-rule download ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  local version = [ feature.get-values <cloog-hidden> : $(properties) ] ;
-  URL on $(targets) = http://www.bastoul.net/cloog/pages/download/cloog-$(version).tar.gz ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions download
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn 2609a965-dda2-4351-837e-b59aa3d579ff '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -f '$(<)'
-  trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  ( cd '$(<:D)' && wget -- '$(URL)' )
-  [ -f '$(<)' ]
-EOS
-}
-
-
-for local version in $(CLOOG_VERSIONS) {
-  if "$(version)" != "trunk" {
-    # Use `README' file as a target representing the completion of
-    # decompression action. It is suitable for the purpose because of the
-    # following reasons;
-    #
-    #   - The name of this file is considered stable even if the version
-    #     changes.
-    #   - This file won't be modified during the build procedure.
-    #
-    make "$(INTRO_ROOT_DIR)/cloog-$(version)/README"
-      : "$(INTRO_ROOT_DIR)/cloog-$(version).tar.gz"
-      : @expand
-      ;
-    explicit "$(INTRO_ROOT_DIR)/cloog-$(version)/README" ;
-  }
-}
-
-rule expand ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions expand
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn cbe1ceb0-c51f-4bcb-ab5b-eec76f282c74 '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -rf '$(<:D)'
-  [ -f '$(>)' ]
-  trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xzvf '$(>)' -C '$(INTRO_ROOT_DIR)'
-  # If the timestamp of the tarball's contents is restored, the modification
-  # time of the source directory could be older than the one of the tarball.
-  # Such behavior is not desirable because the decompression always happens.
-  # Therefore, `touch' is required.
-  touch --no-create '$(<)'
-  [ -f '$(<)' ]
-EOS
-}
-
-
-if trunk in $(CLOOG_VERSIONS) {
-  make "$(INTRO_ROOT_DIR)/cloog-trunk/README"
-    : # no source
-    : @update-trunk
-    ;
-  explicit "$(INTRO_ROOT_DIR)/cloog-trunk/README" ;
-  always "$(INTRO_ROOT_DIR)/cloog-trunk/README" ;
-}
-
-rule update-trunk ( targets * : sources * : properties * )
-{
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions update-trunk
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn 189848b9-2424-45d1-910b-459a00e36516 '$(INTRO_ROOT_DIR)/cloog/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+cloog/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-
-  if [ -f '$(<)' ]; then
-    ( cd '$(INTRO_ROOT_DIR)/cloog-trunk' && git clean -ffdx )
-  fi
-
-  trap "rm -rf '$(INTRO_ROOT_DIR)/cloog-trunk'" ERR HUP INT QUIT TERM
-
-  if [ ! -f '$(<)' ]; then
-    ( cd '$(INTRO_ROOT_DIR)' && git clone 'git://repo.or.cz/cloog.git' cloog-trunk )
-  fi
-  [ -f '$(<)' ]
-  ( cd '$(INTRO_ROOT_DIR)/cloog-trunk' && git pull --ff-only )
-  #( cd '$(INTRO_ROOT_DIR)/cloog-trunk' && ./get_submodules.sh )
-  ( cd '$(INTRO_ROOT_DIR)/cloog-trunk' && ./autogen.sh )
-  touch --no-create '$(<)'
-  [ -f '$(<)' ]
-EOS
-}
-
-
-rule srcdir-req ( properties * )
+rule srcdir-timestamp-req ( properties * )
 {
   local version = [ feature.get-values <cloog-hidden> : $(properties) ] ;
-  return "<source>$(INTRO_ROOT_DIR)/cloog-$(version)/README/$(DEFAULT_PROPERTIES)" ;
+  return "<source>$(INTRO_ROOT_DIR)/cloog-$(version)/528457b5-9e38-4c8f-ac97-fbdb3ccfdbe9" ;
 }
 
-alias srcdir : : <conditional>@srcdir-req ;
-explicit srcdir ;
+alias srcdir-timestamp : : <conditional>@srcdir-timestamp-req ;
+explicit srcdir-timestamp ;
 
 
 rule location-conditional ( properties * )
@@ -192,7 +71,7 @@ make cloog/cloog.h
   : compiler-dep
     ../gmp//install
     ../isl//install
-    srcdir
+    srcdir-timestamp
   : @make-install
   : $(USE_COMPILER)
     $(USE_MULTITARGET)

--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -174,7 +174,7 @@ rule gxx-wrapper-conditional ( properties * )
     result += "<source>../isl//srcdir/<isl-hidden>$(isl)" ;
   }
   if "$(cloog)" != "unspecified" {
-    result += "<source>../cloog//srcdir/<cloog-hidden>$(cloog)" ;
+    result += "<source>../cloog//srcdir-timestamp/<cloog-hidden>$(cloog)" ;
   }
   result += "<location>$(bindir)" ;
   return $(result) ;

--- a/jamroot
+++ b/jamroot
@@ -29,7 +29,6 @@ local .mpfr-latest ;
 local .mpc-latest ;
 local .ppl-latest ;
 local .isl-latest ;
-local .cloog-latest ;
 local .icu4c-latest ;
 local .openmpi-latest ;
 local .boost-latest ;
@@ -143,17 +142,6 @@ local rule get-isl-latest-version ( )
     }
   }
   return "$(.isl-latest)" ;
-}
-
-local rule get-cloog-latest-version ( )
-{
-  if ! "$(.cloog-latest)" {
-    .cloog-latest = [ SHELL "\"$(INTRO_ROOT_DIR)/cloog/latest.sh\" || echo -n error" ] ;
-    if "$(.cloog-latest)" = "error" {
-      errors.error "failed to extract CLooG latest version." ;
-    }
-  }
-  return "$(.cloog-latest)" ;
 }
 
 local rule get-icu4c-latest-version ( )
@@ -298,9 +286,6 @@ ECHO isl-for-gcc... $(isl-for-gcc) ;
 local cloog-for-gcc = [ option.get "with-cloog-for-gcc" : "system" : "IMPLIED" ] ;
 if "$(cloog-for-gcc)" = "IMPLIED" {
   errors.error "`--with-cloog-for-gcc' should be specified with a value." ;
-}
-if "$(cloog-for-gcc)" = "latest" {
-  cloog-for-gcc = [ get-cloog-latest-version ] ;
 }
 if "$(cloog-for-gcc)" != "system" && ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(cloog-for-gcc)" : 1 ] {
   errors.error "an invalid value `$(cloog-for-gcc)' for `--with-cloog-for-gcc'." ;
@@ -648,12 +633,7 @@ if "$(isl)" {
 
 
 local cloog = [ option.get enable-cloog : : latest ] ;
-if $(cloog) = latest
-{
-  cloog = [ get-cloog-latest-version ] ;
-}
-if $(cloog)
-{
+if $(cloog) {
   if [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(cloog)" : 1 ] {
     # Do nothing.
   }


### PR DESCRIPTION
- bootstrap: Changed to dereference `latest` value of `--with-cloog-for-gcc`
  and `--enable-cloog` command-line options into concrete version numbers
  before invoking `bjam`.
- binutils/download.sh: Tweaked.
- binutils/checkout.sh: Tweaked.
- cloog/download.sh: Newly added.
- cloog/checkout.sh: Newly added.
- jamroot: Removed support for `latest` value of `--with-cloog-for-gcc` and
  `--enable-cloog` command-line options.
- cloog/jamfile:
  - Removed downloading and expanding actions.
  - Switched dependency on CLooG source trees from `cloog-$VERSION/README`
    to timestamp files
    `cloog-${VERSION}/528457b5-9e38-4c8f-ac97-fbdb3ccfdbe9`.
- gcc/jamfile: Switched dependency on CLooG source trees, likewise as above.
