### PR TITLE
Tweaked scripts.

### DIFF
--- a/binutils/download.sh
+++ b/binutils/download.sh
@@ -130,7 +130,7 @@ if [ -e "$intro_root/binutils-${version}.tar.bz2.bak" ]; then
 fi
 
 if [ -e "$intro_root/binutils-${version}.bak" ]; then
-  [ -d "$intro_root/binutils-${version}.bak" ] || {
+  [ -f "$old_timestamp_path" ] || {
     echo 'warning: a logic error in commit process, forced to proceed' >&2;
   }
   rm -r "$intro_root/binutils-${version}.bak"

--- a/binutils/jamfile
+++ b/binutils/jamfile
@@ -50,6 +50,16 @@ alias compiler-dep : : <conditional>@compiler-dep-req ;
 explicit compiler-dep ;
 
 
+rule srcdir-timestamp-req ( properties * )
+{
+  local version = [ feature.get-values <binutils-hidden> : $(properties) ] ;
+  return "<source>$(INTRO_ROOT_DIR)/binutils-$(version)/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5" ;
+}
+
+alias srcdir-timestamp : : <conditional>@srcdir-timestamp-req ;
+explicit srcdir-timestamp ;
+
+
 rule location-conditional ( properties * )
 {
   local bindir = [ get-default-bindir "$(PREFIX)" : $(properties) ] ;
@@ -58,7 +68,7 @@ rule location-conditional ( properties * )
 
 make ld.gold
   : compiler-dep
-    "$(INTRO_ROOT_DIR)/binutils-$(BINUTILS)/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5"
+    srcdir-timestamp
   : @make-install
   : <conditional>@location-conditional
     $(USE_COMPILER)

--- a/cloog/download.sh
+++ b/cloog/download.sh
@@ -126,7 +126,7 @@ if [ -e "$intro_root/cloog-${version}.tar.gz.bak" ]; then
 fi
 
 if [ -e "$intro_root/cloog-${version}.bak" ]; then
-  [ -d "$intro_root/cloog-${version}.bak" ] || {
+  [ -f "$old_timestamp_path" ] || {
     echo 'warning: a logic error in commit process, forced to proceed' >&2;
   }
   rm -r "$intro_root/cloog-${version}.bak"

--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -159,7 +159,7 @@ rule gxx-wrapper-conditional ( properties * )
 
   local result ;
   if "$(binutils)" != "unspecified" {
-    result += "<source>$(INTRO_ROOT_DIR)/binutils-$(binutils)/cd9de9b7-e312-49f1-b2a5-24cd4f322ed5" ;
+    result += "<source>../binutils//srcdir-timestamp" ;
   }
   if "$(gmp)" != "unspecified" {
     result += "<source>../gmp//srcdir/<gmp-hidden>$(gmp)" ;


### PR DESCRIPTION
- binutils/download.sh: Tweaked.
- cloog/download.sh: Tweaked.
- binutils/jamfile:
  - Added `srcdir-timestamp`.
  - Changed dependency on CLooG source directory to
    `binutils//srcdir-timestamp`.
- gcc/jamfile: Changed dependency on CLooG source directory, likewise as
  above.
