### PR TITLE
Fixed #32.

### DIFF
--- a/awacs/clang-trunk/jamroot
+++ b/awacs/clang-trunk/jamroot
@@ -5,7 +5,7 @@ import modules ;
 import path ;
 import regex ;
 
-project awacs/clang-trunk : requirements <cxxflags>-std=c++0x <linkflags>-Wl,--no-allow-shlib-undefined <hardcode-dll-paths>false ;
+project awacs/clang-trunk : requirements <cxxflags>-std=c++11 <linkflags>-Wl,--no-allow-shlib-undefined <hardcode-dll-paths>false ;
 
 path-constant AWACS_CLANG_TRUNK : . ;
 

--- a/awacs/gcc-snapshot/jamroot
+++ b/awacs/gcc-snapshot/jamroot
@@ -5,7 +5,7 @@ import modules ;
 import path ;
 import regex ;
 
-project awacs/gcc-snapshot : requirements <cxxflags>-std=c++0x <linkflags>-Wl,--no-allow-shlib-undefined <hardcode-dll-paths>false ;
+project awacs/gcc-snapshot : requirements <cxxflags>-std=c++11 <linkflags>-Wl,--no-allow-shlib-undefined <hardcode-dll-paths>false ;
 
 path-constant AWACS_GCC_SNAPSHOT : . ;
 

--- a/boost/jamfile
+++ b/boost/jamfile
@@ -246,18 +246,7 @@ rule install ( targets * : sources * : properties * )
       errors.error "unknown compiler" ;
     }
   case "c++11" :
-    if [ is-gcc "$(compiler)" ] {
-      OPTIONS on $(targets) += "cxxflags='-std=c++0x'" ;
-    }
-    else if [ is-clang "$(compiler)" ] {
-      OPTIONS on $(targets) += "cxxflags='-std=c++11'" ;
-    }
-    else if [ is-icc "$(compiler)" ] {
-      OPTIONS on $(targets) += "cxxflags='-std=c++11'" ;
-    }
-    else {
-      errors.error "unknown compiler" ;
-    }
+    OPTIONS on $(targets) += "cxxflags='-std=c++11'" ;
   case "" :
     errors.error "the value for `<std>' is empty" ;
   case "*" :

--- a/compilers.jam
+++ b/compilers.jam
@@ -1656,16 +1656,7 @@ rule get-cxxflags ( properties * )
       errors.error "an internal error." ;
     }
   case "c++11" :
-    if [ is-gcc "$(compiler)" ] {
-      # GCC 4.6.x does not support `-std=c++11'.
-      result += "-std=c++0x" ;
-    }
-    else if [ is-clang "$(compiler)" ] || [ is-icc "$(compiler)" ] {
-      result += "-std=c++11" ;
-    }
-    else {
-      errors.error "an internal error." ;
-    }
+    result += "-std=c++11" ;
   case "" :
     errors.error "the value for `<std>' is empty" ;
   case "*" :

--- a/ppl/jamfile
+++ b/ppl/jamfile
@@ -262,13 +262,7 @@ rule make-install ( targets * : sources * : properties * )
         cxxflags = "$(cxxflags) -std=gnu++03" ;
       }
     case "c++11" :
-      if [ is-gcc "$(compiler)" ] {
-        # GCC 4.6.x does not support `-std=gnu++11'.
-        cxxflags = "$(cxxflags) -std=gnu++0x" ;
-      }
-      else {
-        cxxflags = "$(cxxflags) -std=gnu++11" ;
-      }
+      cxxflags = "$(cxxflags) -std=gnu++11" ;
     case "" :
       errors.error "the value for `<std>' is empty" ;
     case "*" :

--- a/template/x86_64-unknown-linux-gnu/site-config.jam
+++ b/template/x86_64-unknown-linux-gnu/site-config.jam
@@ -495,7 +495,7 @@ feature.feature std
   ;
 constant INTRO_STD_COMPILE_PROPERTIES
   : <toolset>gcc,<std>c++03:<cxxflags>-std=c++03
-    <toolset>gcc,<std>c++11:<cxxflags>-std=c++0x
+    <toolset>gcc,<std>c++11:<cxxflags>-std=c++11
     <toolset>clang,<std>c++03:<cxxflags>-std=c++03
     <toolset>clang,<std>c++11:<cxxflags>-std=c++11
     <toolset>intel,<std>c++03:<cxxflags>"-strict-ansi -fno-math-errno"


### PR DESCRIPTION
- compilers.jam: Changed `-std=c++0x` option for GCC to `-std=c++11`. It
  implies that support for GCC 4.6.x has been removed.
- template/x86_64-unknown-linux-gnu/site-config.jam: Likewise.
- boost/jamfile: Likewise.
- awacs/clang-trunk/jamroot: Likewise.
- awacs/gcc-snapshot/jamroot: Likewise.
- ppl/jamfile: Changed `-std=gnu++0x` option for GCC to `-std=gnu++11`. It
  implies that support for GCC 4.6.x has been removed.
