### PR TITLE
Added support of `--without-gdb-check` option.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -36,6 +36,8 @@ args=`getopt                    \
       -l 'enable-lcov::'        \
       -l 'enable-gcovr::'       \
       -l 'enable-gdb::'         \
+      -l 'with-gdb-check::'     \
+      -l 'without-gdb-check'    \
       -l 'enable-opencv::'      \
       -l 'enable-gmp::'         \
       -l 'enable-mpfr::'        \
@@ -70,6 +72,7 @@ gcc_check=yes
 lcov=
 gcovr=
 gdb=
+gdb_check=yes
 opencv=
 gmp=
 mpfr=
@@ -146,6 +149,12 @@ for arg in "${args[@]}"; do
       ;;
     --enable-gdb)
       prev_arg=--enable-gdb
+      ;;
+    --with-gdb-check)
+      prev_arg=--with-gdb-check
+      ;;
+    --without-gdb-check)
+      gdb_check=no
       ;;
     --enable-opencv)
       prev_arg=--enable-opencv
@@ -311,6 +320,23 @@ for arg in "${args[@]}"; do
       else
         gdb="$arg"
       fi
+      ;;
+    --with-gdb-check)
+      case "$arg" in
+      '')
+        gdb_check=yes
+        ;;
+      yes)
+        gdb_check=yes
+        ;;
+      no)
+        gdb_check=no
+        ;;
+      *)
+        echo "bootstrap: option \`--with-gdb-check' doesn't allow argument \`$arg'" >&2
+        exit 1
+        ;;
+      esac
       ;;
     --enable-opencv)
       if [ -z "$arg" ]; then
@@ -539,6 +565,19 @@ fi
 if [ -n "$gdb" ]; then
   delegated_opts=("${delegated_opts[@]}" --enable-gdb="$gdb")
 fi
+
+case "$gdb_check" in
+yes)
+  delegated_opts=("${delegated_opts[@]}" --with-gdb-check)
+  ;;
+no)
+  delegated_opts=("${delegated_opts[@]}" --without-gdb-check)
+  ;;
+*)
+  echo 'bootstrap: an internal error' >&2
+  exit 1
+  ;;
+esac
 
 if [ -n "$opencv" ]; then
   delegated_opts=("${delegated_opts[@]}" --enable-opencv="$opencv")

--- a/gdb/jamfile
+++ b/gdb/jamfile
@@ -201,7 +201,9 @@ $(PROPERTY_DUMP_COMMANDS)
 
   ( cd '$(OBJDIR)' && make --jobs=$(CONCURRENCY) )
 
-  ( cd '$(OBJDIR)' && make check )
+  if [ $(GDB_CHECK) = yes ]; then
+    ( cd '$(OBJDIR)' && make check )
+  fi
 
   ( cd '$(OBJDIR)' && make install )
 

--- a/jamroot
+++ b/jamroot
@@ -510,6 +510,56 @@ if "$(gdb)" {
 }
 
 
+local gdb-check = [ option.get "with-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
+switch "$(gdb-check)" {
+case "UNSPECIFIED" :
+  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
+  switch "$(gdb-check)" {
+  case "UNSPECIFIED" :
+    gdb-check = "yes" ;
+  case "IMPLIED" :
+    gdb-check = "no" ;
+  case "*" :
+    errors.error "`--without-gdb-check' cannot have any value." ;
+  }
+case "IMPLIED" :
+  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
+  switch "$(gdb-check)" {
+  case "UNSPECIFIED" :
+    gdb-check = "yes" ;
+  case "IMPLIED" :
+    errors.error "`--with-gdb-check' and `--without-gdb-check' cannot be specified simultaneously." ;
+  case "*" :
+    errors.error "`--without-gdb-check' cannot have any value." ;
+  }
+case "yes" :
+  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
+  switch "$(gdb-check)" {
+  case "UNSPECIFIED" :
+    gdb-check = "yes" ;
+  case "IMPLIED" :
+    errors.error "`--with-gdb-check' and `--without-gdb-check' cannot be specified simultaneously." ;
+  case "*" :
+    errors.error "`--without-gdb-check' cannot have any value." ;
+  }
+case "no" :
+  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
+  switch "$(gdb-check)" {
+  case "UNSPECIFIED" :
+    gdb-check = "no" ;
+  case "IMPLIED" :
+    errors.error "`--with-gdb-check' and `--without-gdb-check' cannot be specified simultaneously." ;
+  case "*" :
+    errors.error "`--without-gdb-check' cannot have any value." ;
+  }
+case "" :
+  errors.error "the value for `--with-gdb-check' is an empty string." ;
+case "*" :
+  errors.error "an invalid value `$(gdb-check)' is specified for `--with-gdb-check'." ;
+}
+ECHO gdb-check... $(gdb-check) ;
+
+
 local opencv = [ option.get "enable-opencv" : : "latest" ] ;
 if "$(opencv)" = "latest" {
   opencv = [ get-opencv-latest-version ] ;
@@ -975,6 +1025,9 @@ if "$(gcovr)" {
 else {
   ECHO "GCOVR... N/A" ;
 }
+
+constant GDB_CHECK : "$(gdb-check)" ;
+ECHO GDB_CHECK... $(GDB_CHECK) ;
 
 if $(opencv-versions) {
   constant OPENCV_VERSIONS : $(opencv-versions) ;


### PR DESCRIPTION
- bootstrap: Added support of `--with-gdb-check` and `--without-gdb-check`
           options.
- jamroot:
  - Added support of `--with-gdb-check` and `--without-gdb-check` options.
  - Added the definition of `GDB_CHECK` global constant.
- gdb/jamfile: Told the build script to skip GDB's `make check` unless
             `GDB_CHECK` is set to `yes`.
