### PR TITLE
Added support for irregular version strings of GMP.

### DIFF
--- a/gmp/jamfile
+++ b/gmp/jamfile
@@ -107,6 +107,11 @@ rule expand ( targets * : sources * : properties * )
   HERE on $(targets) = [ path.native "$(.here)" ] ;
   HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
   PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
+  # Convert version numbers like `6.0.0a` into normalized ones like `6.0.0`.
+  local version = [ feature.get-values <gmp-hidden> : $(properties) ] ;
+  VERSION on $(targets) = "$(version)" ;
+  normalized-version = [ regex.match "([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)a?" : "$(version)" : 1 ] ;
+  NORMALIZED_VERSION on $(targets) = "$(normalized-version)" ;
 }
 actions expand
 {
@@ -121,6 +126,14 @@ $(PROPERTY_DUMP_COMMANDS)
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
   tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  if [ '$(NORMALIZED_VERSION)' != '$(VERSION)' ]; then
+    # The version string of a tarball might include non-digit characters
+    # like `gmp-6.0.0a.tar.bz2` while the top directory of its contents is
+    # named `gmp-6.0.0`. In order to fit such irregular names to the name
+    # convention expected in sequel build process, the name of the top
+    # directory like `gmp-6.0.0` is renamed to one like `gmp-6.0.0a`.
+    ( cd '$(INTRO_ROOT_DIR)' && mv 'gmp-$(NORMALIZED_VERSION)' 'gmp-$(VERSION)' )
+  fi
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.

--- a/gmp/latest.sh
+++ b/gmp/latest.sh
@@ -22,19 +22,21 @@ wait
 
 versions=`cat "$tempdir"/*`
 rm -r "$tempdir"
-if echo "$versions" | grep -Eq 'gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}\.tar\.((gz)|(bz2))'; then
-  versions=`echo "$versions" | grep -Eo 'gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}\.tar\.((gz)|(bz2))'`
-  versions=`echo "$versions" | grep -Eo 'gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}'`
-  versions=`echo "$versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,2}'`
+# GMP version strings might include non-digit suffixes like `6.0.0a`.
+if echo "$versions" | grep -Eq 'gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}a?\.tar\.((gz)|(bz2))'; then
+  versions=`echo "$versions" | grep -Eo 'gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}a?\.tar\.((gz)|(bz2))'`
+  versions=`echo "$versions" | grep -Eo 'gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}a?'`
+  versions=`echo "$versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,2}a?'`
 fi
 
 local_versions=`cd "$intro_root" && ls -1 gmp-*/README 2>/dev/null || true`
-if echo "$local_versions" | grep -Eq '^gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}/README$'; then
-  local_versions=`echo "$local_versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,2}'`
+if echo "$local_versions" | grep -Eq '^gmp-[[:digit:]]+(\.[[:digit:]]+){0,2}a?/README$'; then
+  local_versions=`echo "$local_versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,2}a?'`
   versions=`echo -e ${versions:+"$versions"'\n'}"$local_versions"`
 fi
 
 [ -n "$versions" ]
-versions=`echo "$versions" | sort -u -t . -k 1,1n -k 2,2n -k 3,3n`
-latest_version=`echo "$versions" | tail -n 1`
+versions="$(echo "$versions" | sort -t . -k 1,1n -k 2,2n -k 3,3n | uniq)"
+latest_version="$(echo "$versions" | tail -n 1)"
+echo "$latest_version" | grep -Eq '[[:digit:]]+(\.[[:digit:]]+){0,2}a?'
 echo -n $latest_version

--- a/jamroot
+++ b/jamroot
@@ -225,7 +225,8 @@ if "$(gmp-for-gcc)" = "IMPLIED" {
 if "$(gmp-for-gcc)" = "latest" {
   gmp-for-gcc = [ get-gmp-latest-version ] ;
 }
-if ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(gmp-for-gcc)" : 1 ] {
+# GMP version strings might include non-digit suffixes like `6.0.0a`.
+if ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)a?$" : "$(gmp-for-gcc)" : 1 ] {
   errors.error "an invalid value `$(gmp-for-gcc)' for `--with-gmp-for-gcc'." ;
 }
 if ! "$(gmp-for-gcc)" in $(gmp-versions) {
@@ -580,7 +581,8 @@ if "$(gmp)" = "latest" {
   gmp = [ get-gmp-latest-version ] ;
 }
 if "$(gmp)" {
-  if ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(gmp)" : 1 ] {
+  # GMP version strings might include non-digit suffixes like `6.0.0a`.
+  if ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)a?$" : "$(gmp)" : 1 ] {
     errors.error "an invalid value `$(gmp)' for `--enable-gmp'." ;
   }
   if ! "$(gmp)" in $(gmp-versions) {


### PR DESCRIPTION
- jamroot: Modified regular expressions to accept irregular version strings
         of GMP.
- gmp/latest.sh: Likewise.
- gmp/jamfile: Added build script to rename the top directory of GMP source
             trees in order to fit irregular version strings to ones
             expected in sequel build procedure.
