### PR TITLE
Fixed #78.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -485,6 +485,18 @@ else
 fi
 delegated_opts=("${delegated_opts[@]}" --with-binutils="$binutils")
 
+if [ "$gmp_for_gcc" = latest ]; then
+  gmp_for_gcc="$("$intro_root/gmp/latest.sh")"
+fi
+# GMP version strings might include non-digit suffixes like `6.0.0a`.
+if echo "$gmp_for_gcc" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+){0,2}a?$'; then
+  "$intro_root/gmp/download.sh" "$gmp_for_gcc"
+elif [ "$gmp_for_gcc" = system ]; then
+  :
+else
+  echo "error: an invalid value \`$gmp_for_gcc' of \`--with-gmp-for-gcc' option" >&2
+  exit 1
+fi
 delegated_opts=("${delegated_opts[@]}" --with-gmp-for-gcc="$gmp_for_gcc")
 
 delegated_opts=("${delegated_opts[@]}" --with-mpfr-for-gcc="$mpfr_for_gcc")
@@ -584,6 +596,16 @@ if [ -n "$opencv" ]; then
 fi
 
 if [ -n "$gmp" ]; then
+  if [ "$gmp" = latest ]; then
+    gmp="$("$intro_root/gmp/latest.sh")"
+  fi
+  # GMP version strings might include non-digit suffixes like `6.0.0a`.
+  if echo "$gmp" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+){0,2}a?$'; then
+    "$intro_root/gmp/download.sh" "$gmp"
+  else
+    echo "error: an invalid value \`$gmp' of \`--enable-gmp' option" >&2
+    exit 1
+  fi
   delegated_opts=("${delegated_opts[@]}" --enable-gmp="$gmp")
 fi
 

--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -162,7 +162,7 @@ rule gxx-wrapper-conditional ( properties * )
     result += "<source>../binutils//srcdir-timestamp" ;
   }
   if "$(gmp)" != "unspecified" {
-    result += "<source>../gmp//srcdir/<gmp-hidden>$(gmp)" ;
+    result += "<source>../gmp//srcdir-timestamp/<gmp-hidden>$(gmp)" ;
   }
   if "$(mpfr)" != "unspecified" {
     result += "<source>../mpfr//srcdir/<mpfr-hidden>$(mpfr)" ;

--- a/gmp/download.sh
+++ b/gmp/download.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+PS4='+gmp/download.sh:$LINENO: '
+set -ex
+
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq 9a2a7760-8595-4663-81b4-bc7b2e50015f "$intro_root/gmp/download.sh"
+
+[ $# -eq 1 ]
+
+version="$1"
+# GMP version strings might include non-digit suffixes like `6.0.0a`.
+echo "$version" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+){0,2}a?$'
+
+( cd "$intro_root" && "$intro_root/util/make-srcdir.sh"                     \
+  --url "http://ftp.jaist.ac.jp/pub/GNU/gmp/gmp-${version}.tar.bz2"         \
+  --url "http://ftp.tsukuba.wide.ad.jp/software/gmp/gmp-${version}.tar.bz2" \
+  --url "http://ftp.nara.wide.ad.jp/pub/GNU/gnu/gmp/gmp-${version}.tar.bz2" \
+  --url "http://www.ring.gr.jp/archives/GNU/gmp/gmp-${version}.tar.bz2"     \
+  --url "ftp://ftp.gnu.org/gnu/gmp/gmp-${version}.tar.bz2"                  \
+  --tarball "gmp-${version}.tar.bz2"                                        \
+  --bzip2                                                                   \
+  --srcdir "gmp-${version}"                                                 \
+  --timestamp 2bf4ddbc-6fd0-44c5-82ce-d66a6eb45809 )

--- a/gmp/jamfile
+++ b/gmp/jamfile
@@ -50,108 +50,14 @@ alias compiler-dep : : <conditional>@compiler-dep-req ;
 explicit compiler-dep ;
 
 
-for local version in $(GMP_VERSIONS) {
-  make "$(INTRO_ROOT_DIR)/gmp-$(version).tar.bz2" : : @download ;
-  explicit "$(INTRO_ROOT_DIR)/gmp-$(version).tar.bz2" ;
-}
-
-rule download ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  local version = [ feature.get-values <gmp-hidden> : $(properties) ] ;
-  URLS on $(targets)  = http://ftp.jaist.ac.jp/pub/GNU/gmp/gmp-$(version).tar.bz2 ;
-  URLS on $(targets) += http://ftp.tsukuba.wide.ad.jp/software/gmp/gmp-$(version).tar.bz2 ;
-  URLS on $(targets) += http://ftp.nara.wide.ad.jp/pub/GNU/gnu/gmp/gmp-$(version).tar.bz2 ;
-  URLS on $(targets) += http://www.ring.gr.jp/archives/GNU/gmp/gmp-$(version).tar.bz2 ;
-  URLS on $(targets) += ftp://ftp.gnu.org/gnu/gmp/gmp-$(version).tar.bz2 ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions download
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn 9abd0cb7-7098-466c-89a8-b0ba19085605 '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -f '$(<)'
-  trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  for url in $(URLS) ; do
-    ( cd '$(<:D)' && wget -- "$url" ) && break
-  done
-  [ -f '$(<)' ]
-EOS
-}
-
-
-for local version in $(GMP_VERSIONS) {
-  # Use `README' file as a target representing the completion of
-  # decompression action. It is suitable for the purpose because of the
-  # following reasons;
-  #
-  #   - The name of this file is considered stable even if the version
-  #     changes.
-  #   - This file won't be modified during the build procedure.
-  #
-  make "$(INTRO_ROOT_DIR)/gmp-$(version)/README"
-    : "$(INTRO_ROOT_DIR)/gmp-$(version).tar.bz2"
-    : @expand
-    ;
-  explicit "$(INTRO_ROOT_DIR)/gmp-$(version)/README" ;
-}
-
-rule expand ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-  # Convert version numbers like `6.0.0a` into normalized ones like `6.0.0`.
-  local version = [ feature.get-values <gmp-hidden> : $(properties) ] ;
-  VERSION on $(targets) = "$(version)" ;
-  normalized-version = [ regex.match "([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)a?" : "$(version)" : 1 ] ;
-  NORMALIZED_VERSION on $(targets) = "$(normalized-version)" ;
-}
-actions expand
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn eb3fcdff-c481-4bd3-b0a0-e28a0f9ae51e '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -rf '$(<:D)'
-  [ -f '$(>)' ]
-  trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
-  if [ '$(NORMALIZED_VERSION)' != '$(VERSION)' ]; then
-    # The version string of a tarball might include non-digit characters
-    # like `gmp-6.0.0a.tar.bz2` while the top directory of its contents is
-    # named `gmp-6.0.0`. In order to fit such irregular names to the name
-    # convention expected in sequel build process, the name of the top
-    # directory like `gmp-6.0.0` is renamed to one like `gmp-6.0.0a`.
-    ( cd '$(INTRO_ROOT_DIR)' && mv 'gmp-$(NORMALIZED_VERSION)' 'gmp-$(VERSION)' )
-  fi
-  # If the timestamp of the tarball's contents is restored, the modification
-  # time of the source directory could be older than the one of the tarball.
-  # Such behavior is not desirable because the decompression always happens.
-  # Therefore, `touch' is required.
-  touch --no-create '$(<)'
-  [ -f '$(<)' ]
-EOS
-}
-
-
-rule srcdir-req ( properties * )
+rule srcdir-timestamp-req ( properties * )
 {
   local version = [ feature.get-values <gmp-hidden> : $(properties) ] ;
-  return "<source>$(INTRO_ROOT_DIR)/gmp-$(version)/README/$(DEFAULT_PROPERTIES)" ;
+  return "<source>$(INTRO_ROOT_DIR)/gmp-$(version)/2bf4ddbc-6fd0-44c5-82ce-d66a6eb45809" ;
 }
 
-alias srcdir : : <conditional>@srcdir-req ;
-explicit srcdir ;
+alias srcdir-timestamp : : <conditional>@srcdir-timestamp-req ;
+explicit srcdir-timestamp ;
 
 
 rule location-conditional ( properties * )
@@ -163,7 +69,7 @@ rule location-conditional ( properties * )
 
 make gmp.h
   : compiler-dep
-    srcdir
+    srcdir-timestamp
   : @make-install
   : $(USE_COMPILER)
     $(USE_MULTITARGET)

--- a/jamroot
+++ b/jamroot
@@ -218,18 +218,15 @@ else {
 ECHO binutils... $(binutils) ;
 
 
-local gmp-for-gcc = [ option.get "with-gmp-for-gcc" : "latest" : "IMPLIED" ] ;
-if "$(gmp-for-gcc)" = "IMPLIED" {
+local gmp-for-gcc = [ option.get with-gmp-for-gcc : system : IMPLIED ] ;
+if "$(gmp-for-gcc)" = IMPLIED {
   errors.error "`--with-gmp-for-gcc' should be specified with a value." ;
 }
-if "$(gmp-for-gcc)" = "latest" {
-  gmp-for-gcc = [ get-gmp-latest-version ] ;
-}
 # GMP version strings might include non-digit suffixes like `6.0.0a`.
-if ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)a?$" : "$(gmp-for-gcc)" : 1 ] {
+if "$(gmp-for-gcc)" != system && ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)a?$" : "$(gmp-for-gcc)" : 1 ] {
   errors.error "an invalid value `$(gmp-for-gcc)' for `--with-gmp-for-gcc'." ;
 }
-if ! "$(gmp-for-gcc)" in $(gmp-versions) {
+if "$(gmp-for-gcc)" != system && ! "$(gmp-for-gcc)" in $(gmp-versions) {
   gmp-versions += "$(gmp-for-gcc)" ;
 }
 ECHO gmp-for-gcc... $(gmp-for-gcc) ;
@@ -576,9 +573,9 @@ if "$(opencv)" {
 }
 
 
-local gmp = [ option.get "enable-gmp" : : "latest" ] ;
-if "$(gmp)" = "latest" {
-  gmp = [ get-gmp-latest-version ] ;
+local gmp = [ option.get enable-gmp : : IMPLIED ] ;
+if "$(gmp)" = IMPLIED {
+  errors.error "`--enable-gmp' should be specified with a value." ;
 }
 if "$(gmp)" {
   # GMP version strings might include non-digit suffixes like `6.0.0a`.
@@ -952,6 +949,9 @@ else {
   ECHO BINUTILS... N/A ;
 }
 
+if "$(gmp-for-gcc)" = system {
+  gmp-for-gcc = ;
+}
 if "$(gmp-for-gcc)" {
   constant GMP_FOR_GCC : "$(gmp-for-gcc)" ;
   ECHO GMP_FOR_GCC... $(GMP_FOR_GCC) ;


### PR DESCRIPTION
- bootstrap:
  - Modified to dereference `latest` value of `--with-gmp-for-gcc` and
    `--enable-gmp` command-line options into concrete version numbers before
    invoking `bjam`.
  - Added support for irregular version strings of GMP.
- gmp/download.sh: Newly added.
- jamroot: Removed support for `latest` value of `--with-gmp-for-gcc` and
  `--enable-gmp` command-line options.
- gmp/jamfile:
  - Removed downloading and expanding actions.
  - Switched dependency on GMP source trees from `gmp-$VERSION/README`
    to timestamp files
    `gmp-${VERSION}/2bf4ddbc-6fd0-44c5-82ce-d66a6eb45809`.
- gcc/jamfile: Switched dependency on GMP source trees, likewise as above.
