### PR TITLE
Fixed #86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /binutils-*/
 /lcov-*/
 /gcovr-*/
+/gdb-*.tar.gz
+/gdb-*.tar.bz2
 /gdb-*/
 /opencv-*.tar.gz
 /opencv-*.tar.bz2

--- a/bootstrap
+++ b/bootstrap
@@ -575,7 +575,17 @@ if [ -n "$gcovr" ]; then
 fi
 
 if [ -n "$gdb" ]; then
-  delegated_opts=("${delegated_opts[@]}" --enable-gdb="$gdb")
+    if [ "$gdb" = latest ]; then
+        gdb="$("$intro_root/gdb/latest.sh")"
+    fi
+    # GDB version strings might include non-digit suffixes like `7.3a`.
+    if echo "$gdb" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+){1,2}a?$'; then
+        "$intro_root/gdb/download.sh" "$gdb"
+    else
+        echo "error: an invalid value \`$gdb' for \`--enable-gdb'" >&2
+        exit 1
+    fi
+    delegated_opts=("${delegated_opts[@]}" --enable-gdb="$gdb")
 fi
 
 case "$gdb_check" in

--- a/gdb/download.sh
+++ b/gdb/download.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+PS4='+gdb/download.sh:$LINENO: '
+set -ex
+
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq a1937486-e141-44db-af69-604179039d8a "$intro_root/gdb/download.sh"
+[ $# -eq 1 ]
+
+version="$1"
+# GDB version strings might include non-digit suffixes like `7.3a`.
+echo "$version" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+){1,2}a?$'
+
+( cd "$intro_root" && "$intro_root/util/make-srcdir.sh"                  \
+  --url "http://ftp.jaist.ac.jp/pub/GNU/gdb/gdb-$version.tar.gz"         \
+  --url "http://ftp.nara.wide.ad.jp/pub/GNU/gnu/gdb/gdb-$version.tar.gz" \
+  --url "ftp://ftp.gnu.org/gnu/gdb/gdb-$version.tar.gz"                  \
+  --tarball "gdb-$version.tar.gz"                                        \
+  --gzip                                                                 \
+  --srcdir "gdb-$version"                                                \
+  --timestamp f4f591f6-9a1d-4ac3-ae2f-ba6463d79680 )

--- a/gdb/jamfile
+++ b/gdb/jamfile
@@ -48,56 +48,14 @@ alias compiler-dep : : <conditional>@compiler-dep-req ;
 explicit compiler-dep ;
 
 
-rule expand-location-conditional ( properties * )
+rule srcdir-timestamp-req ( properties * )
 {
   local version = [ feature.get-values <gdb-hidden> : $(properties) ] ;
-  return "<location>$(INTRO_ROOT_DIR)/gdb-$(version)" ;
+  return "<source>$(INTRO_ROOT_DIR)/gdb-$(version)/f4f591f6-9a1d-4ac3-ae2f-ba6463d79680" ;
 }
 
-make README : : @expand : <conditional>@expand-location-conditional ;
-explicit README ;
-
-rule expand ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  local version = [ feature.get-values <gdb-hidden> : $(properties) ] ;
-  VERSION on $(targets) = "$(version)" ;
-  URLS on $(targets)  = http://ftp.jaist.ac.jp/pub/GNU/gdb/gdb-$(version).tar.bz2 ;
-  URLS on $(targets) += http://ftp.nara.wide.ad.jp/pub/GNU/gnu/gdb/gdb-$(version).tar.bz2 ;
-  URLS on $(targets) += http://www.ring.gr.jp/archives/GNU/gdb/gdb-$(version).tar.bz2 ;
-  URLS on $(targets) += ftp://ftp.gnu.org/gnu/gdb/gdb-$(version).tar.bz2 ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions expand
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn b7ba40a6-bc5b-4d1c-8fb4-96babf537dbd '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -rf '$(INTRO_ROOT_DIR)/gdb-$(VERSION)'
-  tmpdir=`mktemp -d`
-  trap "rm -rf '$(INTRO_ROOT_DIR)/gdb-$(VERSION)'; rm -r '$tmpdir'" ERR HUP INT QUIT TERM
-  for url in $(URLS) ; do
-    ( cd "$tmpdir" && wget -- "$url" ) && break
-  done
-  tar xjvf "$tmpdir"'/gdb-$(VERSION).tar.bz2' -C '$(INTRO_ROOT_DIR)'
-  rm -r "$tmpdir"
-EOS
-}
-
-
-rule srcdir-req ( properties * )
-{
-  local version = [ feature.get-values <gdb-hidden> : $(properties) ] ;
-  return "<source>README/$(DEFAULT_PROPERTIES)" ;
-}
-
-alias srcdir : : <conditional>@srcdir-req ;
-explicit srcdir ;
+alias srcdir-timestamp : : <conditional>@srcdir-timestamp-req ;
+explicit srcdir-timestamp ;
 
 
 rule location-conditional ( properties * )
@@ -108,7 +66,7 @@ rule location-conditional ( properties * )
 
 make gdb
   : compiler-dep
-    srcdir
+    srcdir-timestamp
   : @make-install
   : $(USE_COMPILER)
     $(USE_MULTITARGET)

--- a/jamroot
+++ b/jamroot
@@ -22,7 +22,6 @@ import "$(INTRO_ROOT_DIR)/compilers"
 
 local .lcov-latest ;
 local .gcovr-latest ;
-local .gdb-latest ;
 local .opencv-latest ;
 local .gmp-latest ;
 local .mpfr-latest ;
@@ -65,17 +64,6 @@ local rule get-gcovr-latest-version ( )
     }
   }
   return "$(.gcovr-latest)" ;
-}
-
-local rule get-gdb-latest-version ( )
-{
-  if ! "$(.gdb-latest)" {
-    .gdb-latest = [ SHELL "'$(INTRO_ROOT_DIR)/gdb/latest.sh' || echo -n error" ] ;
-    if "$(.gdb-latest)" = "error" {
-      errors.error "failed to extract GDB latest version." ;
-    }
-  }
-  return "$(.gdb-latest)" ;
 }
 
 local rule get-opencv-latest-version ( )
@@ -496,13 +484,14 @@ else {
 }
 
 
-local gdb = [ option.get enable-gdb : : latest ] ;
-if "$(gdb)" = latest {
-  gdb = [ get-gdb-latest-version ] ;
+local gdb = [ option.get enable-gdb : : IMPLIED ] ;
+if "$(gdb)" = IMPLIED {
+  errors.error "`--enable-gdb' should be specified with a value" ;
 }
 if "$(gdb)" {
-  if ! [ regex.match "^([0-9]+\\.[0-9]+(\\.[0-9]+)?)$" : "$(gdb)" : 1 ] {
-    errors.error "an invalid value `$(gdb)' for `--enable-gdb'." ;
+  # GDB version strings might include non-digit suffixes like `7.3a`.
+  if ! [ regex.match "^([0-9]+\\.[0-9]+(\\.[0-9]+)?)a?$" : "$(gdb)" : 1 ] {
+    errors.error "an invalid value `$(gdb)' for `--enable-gdb'" ;
   }
   ECHO gdb... $(gdb) ;
 }


### PR DESCRIPTION
- .gitignore: Told to ignore downloaded GDB tarballs.
- bootstrap:
  - Modified to dereference `latest` value of `--enable-gdb` command-line
    option into concrete version numbers before invoking `bjam`.
- gdb/download.sh: Newly added.
- jamroot: Removed support for `latest` value of `--enable-gdb` command-line
  option.
- gdb/jamfile:
  - Removed downloading and expanding actions.
  - Switched dependency on GDB source trees from `gdb-$VERSION/README`
    to timestamp files `gdb-$VERSION/f4f591f6-9a1d-4ac3-ae2f-ba6463d79680`.
