### PR TITLE
Reduced the too many number of `wget` retrying.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -698,7 +698,7 @@ if [ ! -d "$prefix/boost/$boost_latest" ]; then
   boost_tag=`echo $boost_latest | sed -e 's/\./_/g'`
   mkdir -p "$prefix/boost"
   pushd "$prefix/boost"
-  wget -q --no-clobber -- "http://downloads.sourceforge.net/project/boost/boost/$boost_latest/boost_${boost_tag}.tar.bz2"
+  wget -q -t 3 --no-clobber -- "http://downloads.sourceforge.net/project/boost/boost/$boost_latest/boost_${boost_tag}.tar.bz2"
   tar xjvf boost_${boost_tag}.tar.bz2
   rm boost_${boost_tag}.tar.bz2
   mv boost_$boost_tag $boost_latest

--- a/clang/jamfile
+++ b/clang/jamfile
@@ -126,16 +126,16 @@ $(PROPERTY_DUMP_COMMANDS)
   cleanup
   trap cleanup ERR HUP INT QUIT TERM
 
-  ( cd '$(<:D)' && wget -- '$(LLVM_SRC_URL)' )
+  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(LLVM_SRC_URL)' )
   [ -f '$(INTRO_ROOT_DIR)/llvm-$(VERSION).src.tar.gz' ]
 
-  ( cd '$(<:D)' && wget -- '$(CLANG_SRC_URL)' )
+  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(CLANG_SRC_URL)' )
   [ -f '$(INTRO_ROOT_DIR)/cfe-$(VERSION).src.tar.gz' ]
 
-  #( cd '$(<:D)' && wget -- '$(CLANG_TOOLS_EXTRA_SRC_URL)' )
+  #( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(CLANG_TOOLS_EXTRA_SRC_URL)' )
   #[ -f '$(INTRO_ROOT_DIR)/clang-tools-extra-$(VERSION).src.tar.gz' ]
 
-  ( cd '$(<:D)' && wget -- '$(COMPILER_RT_SRC_URL)' )
+  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(COMPILER_RT_SRC_URL)' )
   [ -f '$(INTRO_ROOT_DIR)/compiler-rt-$(VERSION).src.tar.gz' ]
 
   [ -f '$(<)' ]

--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -74,7 +74,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
   for url in $(URLS) ; do
-    ( cd '$(<:D)' && wget -- "$url" ) && break
+    ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- "$url" ) && break
   done
   [ -f '$(<)' ]
 EOS

--- a/icu4c/jamfile
+++ b/icu4c/jamfile
@@ -76,7 +76,7 @@ $(PROPERTY_DUMP_COMMANDS)
   set -ex
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  ( cd '$(<:D)' && wget -- '$(URL)' )
+  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(URL)' )
   [ -f '$(<)' ]
 EOS
 }

--- a/mpc/jamfile
+++ b/mpc/jamfile
@@ -77,7 +77,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
   for url in $(URLS) ; do
-    ( cd '$(<:D)' && wget -- "$url" ) && break
+    ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- "$url" ) && break
   done
   [ -f '$(<)' ]
 EOS

--- a/mpfr/jamfile
+++ b/mpfr/jamfile
@@ -80,7 +80,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
   for url in $(URLS) ; do
-    ( cd '$(<:D)' && wget -- "$url" ) && break
+    ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- "$url" ) && break
   done
   [ -f '$(<)' ]
 EOS

--- a/opencv/jamfile
+++ b/opencv/jamfile
@@ -74,7 +74,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
   for url in $(URLS) ; do
-    ( cd '$(<:D)' && wget -- "$url" ) && break
+    ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- "$url" ) && break
   done
   [ -f '$(<)' ]
 EOS

--- a/openmpi/jamfile
+++ b/openmpi/jamfile
@@ -71,7 +71,7 @@ $(PROPERTY_DUMP_COMMANDS)
   set -ex
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  ( cd '$(<:D)' && wget -- '$(URL)' )
+  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(URL)' )
   [ -f '$(<)' ]
 EOS
 }

--- a/ppl/jamfile
+++ b/ppl/jamfile
@@ -72,7 +72,7 @@ $(PROPERTY_DUMP_COMMANDS)
   set -ex
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  ( cd '$(<:D)' && wget -- '$(URL)' )
+  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(URL)' )
   [ -f '$(<)' ]
 EOS
 }

--- a/util/make-srcdir.sh
+++ b/util/make-srcdir.sh
@@ -189,7 +189,7 @@ done
 
 if [ '!' -f "$tarball_path" ]; then
   for url in "${urls[@]}"; do
-    ( cd "$tmpdir_path" && wget -q --no-clobber -- "$url" ) && break
+    ( cd "$tmpdir_path" && wget -q -t 3 --no-clobber -- "$url" ) && break
   done
   if [ "$tarball_basename_tmp" != "$tarball_basename" ]; then
     [ -f "$tmpdir_path/$tarball_basename_tmp" ]

--- a/valgrind/jamfile
+++ b/valgrind/jamfile
@@ -70,7 +70,7 @@ $(PROPERTY_DUMP_COMMANDS)
   set -ex
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  ( cd '$(<:D)' && wget -- '$(URL)' )
+  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(URL)' )
   [ -f '$(<)' ]
 EOS
 }


### PR DESCRIPTION
- bootstrap: Added `-t 3` option to `wget` command because the default
           number of retring, which is equal to 20, is too many for the
           purpose of this project.
- util/make-srcdir.sh: Likewise.
- gcc/jamfile: Likewise.
- clang/jamfile: Likewise.
- icu4c/jamfile: Likewise.
- mpc/jamfile: Likewise.
- mpfr/jamfile: Likewise.
- opencv/jamfile: Likewise.
- openmpi/jamfile: Likewise.
- ppl/jamfile: Likewise.
- valgrind/jamfile: Likewise.
