### PR TITLE
Added scripts applying GCC patches.

### DIFF
--- a/gcc/4.8.3.patch
+++ b/gcc/4.8.3.patch
@@ -1,0 +1,12 @@
+--- libstdc++-v3/libsupc++/eh_ptr.cc	2013-02-04 02:54:05.000000000 +0900
++++ libstdc++-v3/libsupc++/eh_ptr.cc	2014-10-04 12:49:23.703698477 +0900
+@@ -217,6 +217,9 @@
+   __GXX_INIT_DEPENDENT_EXCEPTION_CLASS(dep->unwindHeader.exception_class);
+   dep->unwindHeader.exception_cleanup = __gxx_dependent_exception_cleanup;
+ 
++  __cxa_eh_globals *globals = __cxa_get_globals ();
++  globals->uncaughtExceptions += 1;
++
+ #ifdef _GLIBCXX_SJLJ_EXCEPTIONS
+   _Unwind_SjLj_RaiseException (&dep->unwindHeader);
+ #else

--- a/gcc/4.9.1.patch
+++ b/gcc/4.9.1.patch
@@ -1,0 +1,12 @@
+--- libstdc++-v3/libsupc++/eh_ptr.cc	2014-04-01 03:16:14.000000000 +0900
++++ libstdc++-v3/libsupc++/eh_ptr.cc	2014-10-05 21:35:09.342815104 +0900
+@@ -245,6 +245,9 @@
+   __GXX_INIT_DEPENDENT_EXCEPTION_CLASS(dep->unwindHeader.exception_class);
+   dep->unwindHeader.exception_cleanup = __gxx_dependent_exception_cleanup;
+ 
++  __cxa_eh_globals *globals = __cxa_get_globals ();
++  globals->uncaughtExceptions += 1;
++
+ #ifdef _GLIBCXX_SJLJ_EXCEPTIONS
+   _Unwind_SjLj_RaiseException (&dep->unwindHeader);
+ #else

--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -101,6 +101,20 @@ rule expand ( targets * : sources * : properties * )
 {
   HERE on $(targets) = [ path.native "$(.here)" ] ;
   HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
+
+  local compiler = [ feature.get-values <compiler-hidden> : $(properties) ] ;
+  if [ is-gcc "$(compiler)" ] {
+    # Do nothing.
+  }
+  else if [ is-clang "$(compiler)" ] || [ is-icc "$(compiler)" ] {
+    compiler = [ get-backend-gcc "$(compiler)" ] ;
+  }
+  else {
+    errors.error "an internal error." ;
+  }
+  local version = [ get-frontend-version "$(compiler)" ] ;
+  VERSION on $(targets) = "$(version)" ;
+
   PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
 }
 actions expand
@@ -116,6 +130,9 @@ $(PROPERTY_DUMP_COMMANDS)
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
   tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  if [ -f '$(INTRO_ROOT_DIR)/gcc/$(VERSION).patch' ]; then
+    ( cd '$(<:D)' && patch -F 0 -p0 < '$(INTRO_ROOT_DIR)/gcc/$(VERSION).patch' )
+  fi
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.


### PR DESCRIPTION
- gcc/jamfile: Added scripts applying GCC patches to GCC source trees.
- gcc/4.9.1.patch: A patch for GCC 4.9.1 source tree, which fixes
                 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62258
- gcc/4.8.3.patch: Likewise for GCC 4.8.3.
