### PR TITLE
Fixed #96.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -567,7 +567,16 @@ no)
 esac
 
 if [ -n "$lcov" ]; then
-  delegated_opts=("${delegated_opts[@]}" --enable-lcov="$lcov")
+    if [ "$lcov" = latest ]; then
+        lcov="$("$intro_root/lcov/latest.sh")"
+    fi
+    if echo "$lcov" | grep -Eq '^[[:digit:]]+\.[[:digit:]]+$'; then
+        "$intro_root/lcov/download.sh" "$lcov"
+    else
+        echo "error: an invalid value \`$lcov' for \`--enable-lcov'" >&2
+        exit 1
+    fi
+    delegated_opts=("${delegated_opts[@]}" --enable-lcov="$lcov")
 fi
 
 if [ -n "$gcovr" ]; then

--- a/jamroot
+++ b/jamroot
@@ -20,7 +20,6 @@ import "$(INTRO_ROOT_DIR)/compilers"
 "$(INTRO_ROOT_DIR)/compilers.init" "$(INTRO_ROOT_DIR)" ;
 
 
-local .lcov-latest ;
 local .gcovr-latest ;
 local .opencv-latest ;
 local .gmp-latest ;
@@ -42,17 +41,6 @@ local rule get-boost-latest-version ( )
     }
   }
   return "$(.boost-latest)" ;
-}
-
-local rule get-lcov-latest-version ( )
-{
-  if ! "$(.lcov-latest)" {
-    .lcov-latest = [ SHELL "'$(INTRO_ROOT_DIR)/lcov/latest.sh' || echo -n error" ] ;
-    if "$(.lcov-latest)" = error {
-      errors.error "failed to extract LCOV latest version." ;
-    }
-  }
-  return "$(.lcov-latest)" ;
 }
 
 local rule get-gcovr-latest-version ( )
@@ -454,13 +442,13 @@ case "*" :
 ECHO gcc-check... $(gcc-check) ;
 
 
-local lcov = [ option.get "enable-lcov" : : "latest" ] ;
-if "$(lcov)" = latest {
-  lcov = [ get-lcov-latest-version ] ;
+local lcov = [ option.get enable-lcov : : IMPLIED ] ;
+if "$(lcov)" = IMPLIED {
+  errors.error "`--enable-lcov' should be specified with a value" ;
 }
 if "$(lcov)" {
-  if ! [ regex.match "^([0-9]+(\\.[0-9]+)?)$" : "$(lcov)" : 1 ] {
-    errors.error "an invalid value `$(lcov)' for `--enable-lcov'." ;
+  if ! [ regex.match "^([0-9]+\\.[0-9]+)$" : "$(lcov)" : 1 ] {
+    errors.error "an invalid value `$(lcov)' for `--enable-lcov'" ;
   }
   ECHO "lcov... $(lcov)" ;
 }

--- a/lcov/checkout.sh
+++ b/lcov/checkout.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+PS4='+lcov/checkout.sh:$LINENO: '
+set -ex
+
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq 27110019-7358-4b1d-9495-9014dd303142 "$intro_root/lcov/checkout.sh"
+
+[ $# -eq 0 ]
+
+(cd "$intro_root" && "$intro_root/util/git-checkout.sh"    \
+    --url 'https://github.com/linux-test-project/lcov.git' \
+    --srcdir lcov-trunk                                    \
+    --timestamp e2c10538-d490-4c93-8e19-3fb74e470174)

--- a/lcov/download.sh
+++ b/lcov/download.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+PS4='+lcov/download.sh:$LINENO: '
+set -ex
+
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq 39422c70-fc14-4a31-a6e9-3a6ffc7d903a "$intro_root/lcov/download.sh"
+
+[ $# -eq 1 ]
+
+version="$1"
+echo "$version" | grep -Eq '^[[:digit:]]+\.[[:digit:]]+$'
+
+if [ -d "$intro_root/lcov-trunk" ]; then
+    (cd "$intro_root/lcov-trunk"                             \
+        && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+        && [ -f e2c10538-d490-4c93-8e19-3fb74e470174 ])
+fi
+(cd "$intro_root" && lcov/checkout.sh)
+(cd "$intro_root/lcov-trunk"                             \
+    && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+    && [ -f e2c10538-d490-4c93-8e19-3fb74e470174 ])
+
+(cd "$intro_root/lcov-trunk" && { git tag | grep -Eq "^v$version\$"; })
+
+srcdir_path="$intro_root/lcov-$version"
+timestamp_basename=e2c10538-d490-4c93-8e19-3fb74e470174
+timestamp_path="$srcdir_path/$timestamp_basename"
+
+cleanup ()
+{
+    rm -rf "$srcdir_path"
+}
+
+if [ '!' -f "$timestamp_path" ]; then
+    if [ -e "$srcdir_path" ]; then
+        rm -rf "$srcdir_path"
+    fi
+
+    trap cleanup ERR HUP INT QUIT TERM
+
+    [ '!' -e "$srcdir_path" ]
+    (cd "$intro_root/lcov-trunk" \
+        && git archive --prefix="lcov-$version/" "refs/tags/v$version" | tar -x -C "$intro_root")
+
+    tag_commit_date="$(cd "$intro_root/lcov-trunk" && LANG=C git log -1 --date=iso "refs/tags/v$version")"
+    tag_commit_date="$(echo "$tag_commit_date" | grep -E '^Date:')"
+    if [ "$(echo "$tag_commit_date" | wc -l)" -ne 1 ]; then
+        echo "lcov/download.sh: error: failed to extract the date of the tag" >&2
+        exit 1
+    fi
+    tag_commit_date="$(echo "$tag_commit_date" | sed -e 's/^Date:[[:space:]]*\(.*\)$/\1/')"
+    if echo "$tag_commit_date" | grep -Eq '^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [+-][[:digit:]]{4}$'; then
+        :
+    else
+        echo "lcov/download.sh: error: failed to extract the date of the tag" >&2
+        exit 1
+    fi
+
+    [ '!' -f "$timestamp_path" ]
+    touch --date="$tag_commit_date" "$timestamp_path"
+    find "$srcdir_path" -newer "$timestamp_path" -execdir touch --date="$tag_commit_date" '{}' '+'
+
+    trap - ERR HUP INT QUIT TERM
+fi
+[ -f "$timestamp_path" ]

--- a/lcov/jamfile
+++ b/lcov/jamfile
@@ -42,48 +42,14 @@ alias compiler-dep : : <conditional>@compiler-dep-req ;
 explicit compiler-dep ;
 
 
-make "$(INTRO_ROOT_DIR)/lcov-$(LCOV)/README" : : @export ;
-explicit "$(INTRO_ROOT_DIR)/lcov-$(LCOV)/README" ;
-
-rule export ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  local version = [ feature.get-values <lcov-hidden> : $(properties) ] ;
-  local tag = [ regex.replace "$(version)" "\\." "_" ] ;
-  TAG on $(targets) = "LCOV_$(tag)" ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions export
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn 17543a48-8ec8-4f65-82b1-5cbd00e86bec '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -r '$(<:D)'
-  tmpdir=`mktemp -d`
-  trap "rm -r \"$tmpdir\" '$(<:D)'" ERR HUP INT QUIT TERM
-  cvs -d :pserver:anonymous:@ltp.cvs.sourceforge.net:/cvsroot/ltp login
-  ( cd "$tmpdir" && cvs -z 3 -d :pserver:anonymous@ltp.cvs.sourceforge.net:/cvsroot/ltp export -r '$(TAG)' utils )
-  cvs -d :pserver:anonymous@ltp.cvs.sourceforge.net:/cvsroot/ltp logout
-  ( cd "$tmpdir/utils/analysis" && mv lcov "$(<:D)" )
-  rm -r "$tmpdir"
-  [ -f '$(<)' ]
-EOS
-}
-
-
-rule srcdir-req ( properties * )
+rule srcdir-timestamp-file-req ( properties * )
 {
   local version = [ feature.get-values <lcov-hidden> : $(properties) ] ;
-  return "<source>$(INTRO_ROOT_DIR)/lcov-$(version)/README/$(DEFAULT_PROPERTIES)" ;
+  return "<source>$(INTRO_ROOT_DIR)/lcov-$(version)/e2c10538-d490-4c93-8e19-3fb74e470174" ;
 }
 
-alias srcdir : : <conditional>@srcdir-req ;
-explicit srcdir ;
+alias srcdir-timestamp-file : : <conditional>@srcdir-timestamp-file-req ;
+explicit srcdir-timestamp-file ;
 
 
 rule location-conditional ( properties * )
@@ -94,7 +60,7 @@ rule location-conditional ( properties * )
 
 make lcov
   : compiler-dep
-    srcdir
+    srcdir-timestamp-file
   : @make-install
   : $(USE_COMPILER)
     $(USE_LCOV)

--- a/lcov/latest.sh
+++ b/lcov/latest.sh
@@ -1,46 +1,34 @@
 #!/usr/bin/env bash
 
-intro_root=`(cd \`dirname "$0"\`; cd ..; pwd)`
-grep -Fq 0fe6bce1-7c14-4da4-87f2-90cdbec098b4 "$intro_root/lcov/latest.sh"
-
 set -e
 
-if [ ! -e "$intro_root/lcov-trunk/CVS" ]; then
-  cd "$intro_root" && rm -rf lcov-trunk
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq 0fe6bce1-7c14-4da4-87f2-90cdbec098b4 "$intro_root/lcov/latest.sh"
+
+if [ -d "$intro_root/lcov-trunk" ]; then
+    (cd "$intro_root/lcov-trunk"                             \
+        && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+        && [ -f e2c10538-d490-4c93-8e19-3fb74e470174 ])
+fi
+(cd "$intro_root" && lcov/checkout.sh >/dev/null 2>&1)
+(cd "$intro_root/lcov-trunk"                             \
+    && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+    && [ -f e2c10538-d490-4c93-8e19-3fb74e470174 ])
+
+tags="$(cd "$intro_root/lcov-trunk" && git tag)"
+if echo "$tags" | grep -Eq '^v[[:digit:]]+\.[[:digit:]]+$'; then
+    tmp="$(echo "$tags" | grep -Eo '^v[[:digit:]]+\.[[:digit:]]+$')"
+    versions="$(echo "$tmp" | grep -Eo '[[:digit:]]+\.[[:digit:]]+$')"
 fi
 
-cvs_status=$?
-cvs -d :pserver:anonymous:@ltp.cvs.sourceforge.net:/cvsroot/ltp -Q login >/dev/null 2>&1 || cvs_status=$?
-trap 'cvs -d :pserver:anonymous@ltp.cvs.sourceforge.net:/cvsroot/ltp -q logout' ERR HUP INT QUIT TERM
-
-if [ $cvs_status -eq 0 ]; then
-  if [ ! -e "$intro_root/lcov-trunk/CVS" ]; then
-    ( cd "$intro_root" && cvs -z 3 -d :pserver:anonymous@ltp.cvs.sourceforge.net:/cvsroot/ltp -Q co -d lcov-trunk utils 2>/dev/null || true )
-  else
-    ( cd "$intro_root/lcov-trunk" && cvs -q update 2>/dev/null || true )
-  fi
-
-  if [ -d "$intro_root/lcov-trunk/CVS" ]; then
-    versions=`cd "$intro_root/lcov-trunk/analysis/lcov" && cvs -Q status -v README 2>/dev/null || true`
-    if echo "$versions" | grep -Eq '[[:space:]]LCOV_[[:digit:]]+_[[:digit:]]+[[:space:]]'; then
-      versions=`echo "$versions" | grep -Eo '[[:space:]]LCOV_[[:digit:]]+_[[:digit:]]+[[:space:]]'`
-      versions=`echo "$versions" | grep -Eo '[[:digit:]]+_[[:digit:]]+'`
-      versions=`echo "$versions" | sed -e 's/_/./'`
-    fi
-  fi
-
-  cvs -d :pserver:anonymous@ltp.cvs.sourceforge.net:/cvsroot/ltp -q logout
-fi
-
-trap - ERR HUP INT QUIT TERM
-
-local_versions=`cd "$intro_root" && ls -1 lcov-*/README 2>/dev/null || true`
-if echo "$local_versions" | grep -Eq '^lcov-[[:digit:]]+(\.[[:digit:]]+){0,2}/README$'; then
-  local_versions=`echo "$local_versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,2}'`
-  versions=`echo -e ${versions:+"$versions"'\n'}"$local_versions"`
+local_versions="$(cd "$intro_root" && ls -1 lcov-*/e2c10538-d490-4c93-8e19-3fb74e470174 2>/dev/null || true)"
+if echo "$local_versions" | grep -Eq '^lcov-[[:digit:]]+\.[[:digit:]]+/e2c10538-d490-4c93-8e19-3fb74e470174$'; then
+    local_versions="$(echo "$local_versions" | grep -Eo '^lcov-[[:digit:]]+\.[[:digit:]]+/')"
+    local_versions="$(echo "$local_versions" | grep -Eo '[[:digit:]]+\.[[:digit:]]+')"
+    versions="$(echo -e ${versions:+"$versions"\\n}"$local_versions")"
 fi
 
 [ -n "$versions" ]
-versions=`echo "$versions" | sort -u -t . -k 1,1n -k 2,2n -k 3,3n`
-latest_version=`echo "$versions" | tail -n 1`
+versions="$(echo "$versions" | sort -V -u)"
+latest_version=$(echo "$versions" | tail -n 1)
 echo -n $latest_version


### PR DESCRIPTION
- bootstrap:
  - Modified to dereference `latest` value of `--enable-lcov` command-line
    option into concrete version numbers before invoking `bjam`.
  - Modified to prepare LCOV source trees before invoking `bjam`.
- jamroot: Removed support for `latest` value of `--enable-lcov`
         command-line option.
- lcov/checkout.sh: Newly added.
- lcov/latest.sh: Fixed to use git repository.
- lcov/download.sh: Newly added.
- lcov/jamfile:
  - Removed downloading and expanding actions.
  - Switched dependency on LCOV source trees from `lcov-$VERSION/README`
    to timestamp files `lcov-$VERSION/e2c10538-d490-4c93-8e19-3fb74e470174`.
