### PR TITLE
Removed `-v` option from `tar` command.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -708,7 +708,7 @@ if [ ! -d "$prefix/boost/$boost_latest" ]; then
   mkdir -p "$prefix/boost"
   pushd "$prefix/boost"
   wget -q -t 3 --no-clobber -- "http://downloads.sourceforge.net/project/boost/boost/$boost_latest/boost_${boost_tag}.tar.bz2"
-  tar xjvf boost_${boost_tag}.tar.bz2
+  tar xjf boost_${boost_tag}.tar.bz2
   rm boost_${boost_tag}.tar.bz2
   mv boost_$boost_tag $boost_latest
   if [ -f "$intro_root/boost/$boost_latest.patch" ]; then

--- a/clang/jamfile
+++ b/clang/jamfile
@@ -203,25 +203,25 @@ $(PROPERTY_DUMP_COMMANDS)
   }
   trap cleanup ERR HUP INT QUIT TERM
 
-  tar xzvf '$(INTRO_ROOT_DIR)/llvm-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
+  tar xzf '$(INTRO_ROOT_DIR)/llvm-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
   [ -d '$(INTRO_ROOT_DIR)/llvm-$(VERSION).src' ]
   ( cd '$(INTRO_ROOT_DIR)' && mv -nT 'llvm-$(VERSION).src' 'llvm-$(VERSION)' )
   [ -d '$(INTRO_ROOT_DIR)/llvm-$(VERSION)' ]
   [ ! -e '$(INTRO_ROOT_DIR)/llvm-$(VERSION).src' ]
 
-  tar xzvf '$(INTRO_ROOT_DIR)/cfe-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
+  tar xzf '$(INTRO_ROOT_DIR)/cfe-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
   [ -d '$(INTRO_ROOT_DIR)/cfe-$(VERSION).src' ]
   ( cd '$(INTRO_ROOT_DIR)' && mv -nT 'cfe-$(VERSION).src' 'llvm-$(VERSION)/tools/clang' )
   [ -d '$(INTRO_ROOT_DIR)/llvm-$(VERSION)/tools/clang' ]
   [ ! -e '$(INTRO_ROOT_DIR)/cfe-$(VERSION).src' ]
 
-  #tar xzvf '$(INTRO_ROOT_DIR)/clang-tools-extra-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
+  #tar xzf '$(INTRO_ROOT_DIR)/clang-tools-extra-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
   #[ -d '$(INTRO_ROOT_DIR)/clang-tools-extra-$(VERSION).src' ]
   #( cd '$(INTRO_ROOT_DIR)' && mv -nT 'clang-tools-extra-$(VERSION).src' 'llvm-$(VERSION)/tools/clang/tools/extra' )
   #[ -d '$(INTRO_ROOT_DIR)/llvm-$(VERSION)/tools/clang/tools/extra' ]
   #[ ! -e '$(INTRO_ROOT_DIR)/clang-tools-extra-$(VERSION).src' ]
 
-  tar xzvf '$(INTRO_ROOT_DIR)/compiler-rt-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
+  tar xzf '$(INTRO_ROOT_DIR)/compiler-rt-$(VERSION).src.tar.gz' -C '$(INTRO_ROOT_DIR)'
   [ -d '$(INTRO_ROOT_DIR)/compiler-rt-$(VERSION).src' ]
   ( cd '$(INTRO_ROOT_DIR)' && mv -nT 'compiler-rt-$(VERSION).src' 'llvm-$(VERSION)/projects/compiler-rt' )
   [ -d '$(INTRO_ROOT_DIR)/llvm-$(VERSION)/projects/compiler-rt' ]

--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -129,7 +129,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xjf '$(>)' -C '$(INTRO_ROOT_DIR)'
   if [ -f '$(INTRO_ROOT_DIR)/gcc/$(VERSION).patch' ]; then
     ( cd '$(<:D)' && patch -F 0 -p0 < '$(INTRO_ROOT_DIR)/gcc/$(VERSION).patch' )
   fi

--- a/icu4c/jamfile
+++ b/icu4c/jamfile
@@ -118,7 +118,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(INTRO_ROOT_DIR)/icu'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(INTRO_ROOT_DIR)/icu' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xzvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xzf '$(>)' -C '$(INTRO_ROOT_DIR)'
   [ -d '$(INTRO_ROOT_DIR)/icu' ]
   mv -n '$(INTRO_ROOT_DIR)/icu' '$(<:D)'
   # If the timestamp of the tarball's contents is restored, the modification

--- a/isl/jamfile
+++ b/isl/jamfile
@@ -82,7 +82,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   trap "rm -rf '$(<:D)'" ERR HUP INT QUIT TERM
   [ -f '$(INTRO_ROOT_DIR)/isl-trunk/ChangeLog' ]
-  ( cd '$(INTRO_ROOT_DIR)/isl-trunk' && git archive --prefix='isl-$(VERSION)/' 'isl-$(VERSION)' | tar -xv -C '$(INTRO_ROOT_DIR)' )
+  ( cd '$(INTRO_ROOT_DIR)/isl-trunk' && git archive --prefix='isl-$(VERSION)/' 'isl-$(VERSION)' | tar -x -C '$(INTRO_ROOT_DIR)' )
   ( cd '$(INTRO_ROOT_DIR)/isl-$(VERSION)' && ./autogen.sh )
   [ -f '$(<)' ]
 EOS

--- a/mpc/jamfile
+++ b/mpc/jamfile
@@ -118,7 +118,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xzvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xzf '$(>)' -C '$(INTRO_ROOT_DIR)'
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.

--- a/mpfr/jamfile
+++ b/mpfr/jamfile
@@ -121,7 +121,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xjf '$(>)' -C '$(INTRO_ROOT_DIR)'
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.

--- a/opencv/jamfile
+++ b/opencv/jamfile
@@ -115,7 +115,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xzvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xzf '$(>)' -C '$(INTRO_ROOT_DIR)'
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.

--- a/openmpi/jamfile
+++ b/openmpi/jamfile
@@ -109,7 +109,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xjf '$(>)' -C '$(INTRO_ROOT_DIR)'
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.

--- a/ppl/jamfile
+++ b/ppl/jamfile
@@ -110,7 +110,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xjf '$(>)' -C '$(INTRO_ROOT_DIR)'
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.

--- a/valgrind/jamfile
+++ b/valgrind/jamfile
@@ -110,7 +110,7 @@ $(PROPERTY_DUMP_COMMANDS)
   rm -rf '$(<:D)'
   [ -f '$(>)' ]
   trap "rm -rf '$(>)' '$(<:D)'" ERR HUP INT QUIT TERM
-  tar xjvf '$(>)' -C '$(INTRO_ROOT_DIR)'
+  tar xjf '$(>)' -C '$(INTRO_ROOT_DIR)'
   # If the timestamp of the tarball's contents is restored, the modification
   # time of the source directory could be older than the one of the tarball.
   # Such behavior is not desirable because the decompression always happens.


### PR DESCRIPTION
- bootstrap: Removed `-v` option from `tar` command because they are little
           useful in spite of excess output.
- gcc/jamfile: Likewise.
- clang/jamfile: Likewise.
- icu4c/jamfile: Likewise.
- isl/jamfile: Likewise.
- mpfr/jamfile: Likewise.
- mpc/jamfile: Likewise.
- opencv/jamfile: Likewise.
- openmpi/jamfile: Likewise.
- ppl/jamfile: Likewise.
- valgrind/jamfile: Likewise.
