### PR TITLE
Added `--disable-mpi-fortran` in building of OpenMPI.

### DIFF
--- a/openmpi/jamfile
+++ b/openmpi/jamfile
@@ -201,8 +201,7 @@ rule make-install ( targets * : sources * : properties * )
     errors.error "an internal error" ;
   }
 
-  OPTIONS on $(targets) += "--disable-mpi-f77" ;
-  OPTIONS on $(targets) += "--disable-mpi-f90" ;
+  OPTIONS on $(targets) += "--disable-mpi-fortran" ;
   OPTIONS on $(targets) += "--disable-mpi-cxx" ;
 
   local link = [ feature.get-values <link> : $(properties) ] ;


### PR DESCRIPTION
- openmpi/jamfile: `--disable-mpi-f77` and `--disable-mpi-f90` command-line
                 options were replaced by `--disable-mpi-fortran` because
                 the formers are no longer valid.
