### PR TITLE
Fixed #109.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -592,7 +592,16 @@ if [ -n "$lcov" ]; then
 fi
 
 if [ -n "$gcovr" ]; then
-  delegated_opts=("${delegated_opts[@]}" --enable-gcovr="$gcovr")
+    if [ "$gcovr" = latest ]; then
+        gcovr="$("$intro_root/gcovr/latest.sh")"
+    fi
+    if echo "$gcovr" | grep -Eq '^[[:digit:]]+\.[[:digit:]]+$'; then
+        "$intro_root/gcovr/download.sh" "$gcovr"
+    else
+        echo "error: an invalid value \`$gcovr' for \`--enable-gcovr'" >&2
+        exit 1
+    fi
+    delegated_opts=("${delegated_opts[@]}" --enable-gcovr="$gcovr")
 fi
 
 if [ -n "$gdb" ]; then

--- a/gcovr/checkout.sh
+++ b/gcovr/checkout.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+PS4='+gcovr/checkout.sh:$LINENO: '
+set -ex
+
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq c866f004-83df-4d02-8317-05ddfdd8bc1c "$intro_root/gcovr/checkout.sh"
+
+[ $# -eq 0 ]
+
+(cd "$intro_root" && "$intro_root/util/git-checkout.sh" \
+    --url 'https://github.com/gcovr/gcovr.git'          \
+    --srcdir gcovr-trunk                                \
+    --timestamp fb301e39-8f74-4e35-8428-9b3b48a324bc)

--- a/gcovr/download.sh
+++ b/gcovr/download.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+PS4='+gcovr/download.sh:$LINENO: '
+set -ex
+
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq daa9f568-1871-4b1f-898c-5fd03d9c5e0f "$intro_root/gcovr/download.sh"
+
+[ $# -eq 1 ]
+
+version="$1"
+echo "$version" | grep -Eq '^[[:digit:]]+\.[[:digit:]]+$'
+
+if [ -d "$intro_root/gcovr-trunk" ]; then
+    (cd "$intro_root/gcovr-trunk"                            \
+        && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+        && [ -f fb301e39-8f74-4e35-8428-9b3b48a324bc ])
+fi
+(cd "$intro_root" && gcovr/checkout.sh)
+(cd "$intro_root/gcovr-trunk"                            \
+    && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+    && [ -f fb301e39-8f74-4e35-8428-9b3b48a324bc ])
+
+(cd "$intro_root/gcovr-trunk" && { git tag | grep -Eq "^$version\$"; })
+
+srcdir_path="$intro_root/gcovr-$version"
+timestamp_basename=fb301e39-8f74-4e35-8428-9b3b48a324bc
+timestamp_path="$srcdir_path/$timestamp_basename"
+
+cleanup ()
+{
+    rm -rf "$srcdir_path"
+}
+
+if [ '!' -f "$timestamp_path" ]; then
+    if [ -e "$srcdir_path" ]; then
+        rm -rf "$srcdir_path"
+    fi
+
+    trap cleanup ERR HUP INT QUIT TERM
+
+    [ '!' -e "$srcdir_path" ]
+    (cd "$intro_root/gcovr-trunk" \
+        && git archive --prefix="gcovr-$version/" "refs/tags/$version" | tar -x -C "$intro_root")
+
+    tag_commit_date="$(cd "$intro_root/gcovr-trunk" && LANG=C git log -1 --date=iso "refs/tags/$version")"
+    tag_commit_date="$(echo "$tag_commit_date" | grep -E '^Date:')"
+    if [ "$(echo "$tag_commit_date" | wc -l)" -ne 1 ]; then
+        echo "gcovr/download.sh: error: failed to extract the date of the tag" >&2
+        exit 1
+    fi
+    tag_commit_date="$(echo "$tag_commit_date" | sed -e 's/^Date:[[:space:]]*\(.*\)$/\1/')"
+    if echo "$tag_commit_date" | grep -Eq '^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2} [+-][[:digit:]]{4}$'; then
+        :
+    else
+        echo "gcovr/download.sh: error: failed to extract the date of the tag" >&2
+        exit 1
+    fi
+
+    [ '!' -f "$timestamp_path" ]
+    touch --date="$tag_commit_date" "$timestamp_path"
+    find "$srcdir_path" -newer "$timestamp_path" -execdir touch --date="$tag_commit_date" '{}' '+'
+
+    trap - ERR HUP INT QUIT TERM
+fi
+[ -f "$timestamp_path" ]

--- a/gcovr/jamfile
+++ b/gcovr/jamfile
@@ -42,45 +42,14 @@ alias compiler-dep : : <conditional>@compiler-dep-req ;
 explicit compiler-dep ;
 
 
-make "$(INTRO_ROOT_DIR)/gcovr-$(GCOVR)/README.txt" : : @export ;
-explicit "$(INTRO_ROOT_DIR)/gcovr-$(GCOVR)/README.txt" ;
-
-rule export ( targets * : sources * : properties * )
-{
-  HERE on $(targets) = [ path.native "$(.here)" ] ;
-  HERE_RELATIVE on $(targets) = [ path.native "$(.here-relative)" ] ;
-  local version = [ feature.get-values <gcovr-hidden> : $(properties) ] ;
-  VERSION on $(targets) = "$(version)" ;
-  PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
-}
-actions export
-{
-  bash -s << 'EOS'
-  exec >> '$(STDOUT_)' 2>> '$(STDERR_)'
-$(PROPERTY_DUMP_COMMANDS)
-  LINENO_ADJ=`grep -Fn c7201563-8030-48ca-af11-da32a10345d6 '$(HERE)/jamfile' | grep -Eo '^[[:digit:]]+'`
-  LINENO_ADJ=`expr $LINENO_ADJ - $LINENO + 1`
-  PS4='+$(HERE_RELATIVE)/jamfile:`expr $LINENO + $LINENO_ADJ`: '
-  set -ex
-  rm -r '$(<:D)'
-  trap "rm -r '$(<:D)'" ERR HUP INT QUIT TERM
-  # `gcovr` script includes `$Date$` keyword, and `svn export` will replace
-  # it with local time. However, in some locales (e.g. `ja_JP.UTF-8`) it
-  # makes trouble because of non-ASCII characters.
-  ( cd '$(INTRO_ROOT_DIR)' && LANG=C LC_ALL=C LC_TIME=C svn export --non-interactive --trust-server-cert 'https://software.sandia.gov/svn/public/fast/gcovr/tags/$(VERSION)' 'gcovr-$(VERSION)' )
-  [ -f '$(<)' ]
-EOS
-}
-
-
-rule srcdir-req ( properties * )
+rule srcdir-timestamp-file-req ( properties * )
 {
   local version = [ feature.get-values <gcovr-hidden> : $(properties) ] ;
-  return "<source>$(INTRO_ROOT_DIR)/gcovr-$(version)/README.txt/$(DEFAULT_PROPERTIES)" ;
+  return "<source>$(INTRO_ROOT_DIR)/gcovr-$(version)/fb301e39-8f74-4e35-8428-9b3b48a324bc" ;
 }
 
-alias srcdir : : <conditional>@srcdir-req ;
-explicit srcdir ;
+alias srcdir-timestamp-file : : <conditional>@srcdir-timestamp-file-req ;
+explicit srcdir-timestamp-file ;
 
 
 rule location-conditional ( properties * )
@@ -91,7 +60,7 @@ rule location-conditional ( properties * )
 
 make gcovr
   : compiler-dep
-    srcdir
+    srcdir-timestamp-file
   : @make-install
   : $(USE_COMPILER)
     $(USE_GCOVR)

--- a/gcovr/latest.sh
+++ b/gcovr/latest.sh
@@ -1,24 +1,32 @@
 #!/usr/bin/env bash
 
-intro_root=`(cd \`dirname "$0"\`; cd ..; pwd)`
-grep -Fq 020a9f0b-6a09-47f4-9137-4941a7374ef2 "$intro_root/gcovr/latest.sh"
-
 set -e
 
-# `--non-interactive' option disables interactive prompting in case of failure to validate server certificate.
-versions=`svn ls --non-interactive --trust-server-cert https://software.sandia.gov/svn/public/fast/gcovr/tags 2>/dev/null || true`
-if echo "$versions" | grep -Eq '^[[:digit:]]+(\.[[:digit:]]+){0,2}/'; then
-  versions=`echo "$versions" | grep -Eo '^[[:digit:]]+(\.[[:digit:]]+){0,2}/'`
-  versions=`echo "$versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,2}'`
-fi
+intro_root="$(cd "$(dirname "$0")"; cd ..; pwd)"
+grep -Fq 020a9f0b-6a09-47f4-9137-4941a7374ef2 "$intro_root/gcovr/latest.sh"
 
-local_versions=`cd "$intro_root" && ls -1 gcovr-*/README.txt 2>/dev/null || true`
-if echo "$local_versions" | grep -Eq '^gcovr-[[:digit:]]+(\.[[:digit:]]+){0,2}/README.txt$'; then
-  local_versions=`echo "$local_versions" | grep -Eo '[[:digit:]]+(\.[[:digit:]]+){0,2}'`
-  versions=`echo -e ${versions:+"$versions"'\n'}"$local_versions"`
+if [ -d "$intro_root/gcovr-trunk" ]; then
+    (cd "$intro_root/gcovr-trunk"                            \
+        && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+        && [ -f fb301e39-8f74-4e35-8428-9b3b48a324bc ])
+fi
+(cd "$intro_root" && gcovr/checkout.sh >/dev/null 2>&1)
+(cd "$intro_root/gcovr-trunk"                            \
+    && [ "$(pwd)" = "$(git rev-parse --show-toplevel)" ] \
+    && [ -f fb301e39-8f74-4e35-8428-9b3b48a324bc ])
+
+tags="$(cd "$intro_root/gcovr-trunk" && git tag)"
+echo "$tags" | grep -Eq '^[[:digit:]]+\.[[:digit:]]+$'
+versions="$(echo "$tags" | grep -Eo '^[[:digit:]]+\.[[:digit:]]+$')"
+
+local_versions="$(cd "$intro_root" && ls -1 gcovr-*/fb301e39-8f74-4e35-8428-9b3b48a324bc 2>/dev/null || true)"
+if echo "$local_versions" | grep -Eq '^gcovr-[[:digit:]]+\.[[:digit:]]+/fb301e39-8f74-4e35-8428-9b3b48a324bc$'; then
+    local_versions="$(echo "$local_versions" | grep -Eo '^gcovr-[[:digit:]]+\.[[:digit:]]+/')"
+    local_versions="$(echo "$local_versions" | grep -Eo '[[:digit:]]+\.[[:digit:]]+')"
+    versions="$(echo -e ${versions:+"$versions"\\n}"$local_versions")"
 fi
 
 [ -n "$versions" ]
-versions=`echo "$versions" | sort -u -t . -k 1,1n -k 2,2n -k 3,3n`
-latest_version=`echo "$versions" | tail -n 1`
+versions="$(echo "$versions" | sort -V -u)"
+latest_version=$(echo "$versions" | tail -n 1)
 echo -n $latest_version

--- a/jamroot
+++ b/jamroot
@@ -20,7 +20,6 @@ import "$(INTRO_ROOT_DIR)/compilers"
 "$(INTRO_ROOT_DIR)/compilers.init" "$(INTRO_ROOT_DIR)" ;
 
 
-local .gcovr-latest ;
 local .opencv-latest ;
 local .gmp-latest ;
 local .mpfr-latest ;
@@ -41,17 +40,6 @@ local rule get-boost-latest-version ( )
     }
   }
   return "$(.boost-latest)" ;
-}
-
-local rule get-gcovr-latest-version ( )
-{
-  if ! "$(.gcovr-latest)" {
-    .gcovr-latest = [ SHELL "'$(INTRO_ROOT_DIR)/gcovr/latest.sh' || echo -n error" ] ;
-    if "$(.gcovr-latest)" = error {
-      errors.error "failed to extract gcovr latest version." ;
-    }
-  }
-  return "$(.gcovr-latest)" ;
 }
 
 local rule get-opencv-latest-version ( )
@@ -457,13 +445,13 @@ else {
 }
 
 
-local gcovr = [ option.get "enable-gcovr" : : "latest" ] ;
-if "$(gcovr)" = latest {
-  gcovr = [ get-gcovr-latest-version ] ;
+local gcovr = [ option.get enable-gcovr : : IMPLIED ] ;
+if "$(gcovr)" = IMPLIED {
+  errors.error "`--enable-gcovr' should be specified with a value" ;
 }
 if "$(gcovr)" {
-  if ! [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(gcovr)" : 1 ] {
-    errors.error "an invalid value `$(gcovr)' for `--enable-gcovr'." ;
+  if ! [ regex.match "^([0-9]+\\.[0-9]+)$" : "$(gcovr)" : 1 ] {
+    errors.error "an invalid value `$(gcovr)' for `--enable-gcovr'" ;
   }
   ECHO "gcovr... $(gcovr)" ;
 }


### PR DESCRIPTION
- bootstrap:
  - Modified to dereference `latest` value of `--with-gcovr` command-line
    option into concrete version numbers before invoking `bjam`.
  - Modified to prepare gcovr source trees before invoking `bjam`.
- jamroot: Removed support for `latest` value of `--enable-gcovr`
         command-line option.
- gcovr/checkout.sh: Newly added.
- gcovr/latest.sh: Fixed to use git repository.
- gcovr/download.sh: Newly added.
- gcovr/jamfile:
  - Removed downloading and expanding actions.
  - Switched dependency on gcovr source trees from
    `gcovr-$VERSION/README.txt` to timestamp files
    `gcovr-$VERSION/fb301e39-8f74-4e35-8428-9b3b48a324bc`.
