### PR TITLE
Added checks of plugin support in underlying Binutils.

### DIFF
--- a/binutils/jamfile
+++ b/binutils/jamfile
@@ -18,9 +18,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -168,22 +168,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local cc-for-target = [ get-cc "$(PREFIX)" : $(properties) ] ;
@@ -198,22 +195,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXX_FOR_TARGET='$(cxx-for-target-native)'" ;
   }
 
-  local ar-for-target = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar-for-target)" {
-    local ar-for-target-native = [ path.native "$(ar-for-target)" ] ;
-    OPTIONS on $(targets) += "AR_FOR_TARGET='$(ar-for-target-native)'" ;
+  local ar-for-target-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-for-target-command-substitution)" {
+    OPTIONS on $(targets) += "AR_FOR_TARGET=\"$(ar-for-target-command-substitution)\"" ;
   }
 
-  local ranlib-for-target = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib-for-target)" {
-    local ranlib-for-target-native = [ path.native "$(ranlib-for-target)" ] ;
-    OPTIONS on $(targets) += "RANLIB_FOR_TARGET='$(ranlib-for-target-native)'" ;
+  local ranlib-for-target-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-for-target-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB_FOR_TARGET=\"$(ranlib-for-target-command-substitution)\"" ;
   }
 
-  local nm-for-target = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm-for-target)" {
-    local nm-for-target-native = [ path.native "$(nm-for-target)" ] ;
-    OPTIONS on $(targets) += "NM_FOR_TARGET='$(nm-for-target-native)'" ;
+  local nm-for-target-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-for-target-command-substitution)" {
+    OPTIONS on $(targets) += "NM_FOR_TARGET=\"$(nm-for-target-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/clang/jamfile
+++ b/clang/jamfile
@@ -21,9 +21,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -580,22 +580,19 @@ rule make-install ( targets * : sources * : properties * )
     }
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/cloog/jamfile
+++ b/cloog/jamfile
@@ -16,9 +16,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -214,22 +214,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/compilers.jam
+++ b/compilers.jam
@@ -1688,7 +1688,7 @@ rule get-cxxflags ( properties * )
   return "$(result:J= )" ;
 }
 
-rule get-ar ( prefix : properties * : gcc-for-clang ? )
+rule get-ar-command-substitution ( prefix : properties * : gcc-for-clang ? )
 {
   local compiler = [ feature.get-values <compiler-hidden> : $(properties) ] ;
   if ! [ is-valid "$(compiler)" ] {
@@ -1705,7 +1705,7 @@ rule get-ar ( prefix : properties * : gcc-for-clang ? )
     }
     else {
       # GCC newer than or equal to 4.8.x. `gcc-ar` is provided.
-      result = "$(compiler-prefix)/bin/gcc-ar" ;
+      result = "`if '$(compiler-prefix)/bin/gcc-ar' -h | grep -Eq 'supported targets:.*[[:space:]]plugin([[:space:]]|$)'; then echo '$(compiler-prefix)/bin/gcc-ar'; else which ar; fi`" ;
     }
   }
   else if [ is-clang "$(compiler)" ] {
@@ -1720,7 +1720,7 @@ rule get-ar ( prefix : properties * : gcc-for-clang ? )
   return "$(result)" ;
 }
 
-rule get-ranlib ( prefix : properties * : gcc-for-clang ? )
+rule get-ranlib-command-substitution ( prefix : properties * : gcc-for-clang ? )
 {
   local compiler = [ feature.get-values <compiler-hidden> : $(properties) ] ;
   if ! [ is-valid "$(compiler)" ] {
@@ -1737,7 +1737,7 @@ rule get-ranlib ( prefix : properties * : gcc-for-clang ? )
     }
     else {
       # GCC newer than or equal to 4.8.x. `gcc-ranlib` is provided.
-      result = "$(compiler-prefix)/bin/gcc-ranlib" ;
+      result = "`if '$(compiler-prefix)/bin/gcc-ranlib' -h | grep -Eq 'supported targets:.*[[:space:]]plugin([[:space:]]|$)'; then echo '$(compiler-prefix)/bin/gcc-ranlib'; else which ranlib; fi`" ;
     }
   }
   else if [ is-clang "$(compiler)" ] {
@@ -1752,7 +1752,7 @@ rule get-ranlib ( prefix : properties * : gcc-for-clang ? )
   return "$(result)" ;
 }
 
-rule get-nm ( prefix : properties * : gcc-for-clang ? )
+rule get-nm-command-substitution ( prefix : properties * : gcc-for-clang ? )
 {
   local compiler = [ feature.get-values <compiler-hidden> : $(properties) ] ;
   if ! [ is-valid "$(compiler)" ] {
@@ -1769,7 +1769,7 @@ rule get-nm ( prefix : properties * : gcc-for-clang ? )
     }
     else {
       # GCC newer than or equal to 4.8.x. `gcc-nm` is provided.
-      result = "$(compiler-prefix)/bin/gcc-nm" ;
+      result = "`if '$(compiler-prefix)/bin/gcc-nm' -h | grep -Eq 'supported targets:.*[[:space:]]plugin([[:space:]]|$)'; then echo '$(compiler-prefix)/bin/gcc-nm'; else which nm; fi`" ;
     }
   }
   else if [ is-clang "$(compiler)" ] {

--- a/gdb/jamfile
+++ b/gdb/jamfile
@@ -14,9 +14,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-compiler-triplets
     get-cc
     get-cxx
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -124,22 +124,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXX='$(cxx-native)'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local cc-for-target = [ get-cc "$(PREFIX)" : $(properties) ] ;
@@ -154,22 +151,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXX_FOR_TARGET='$(cxx-for-target-native)'" ;
   }
 
-  local ar-for-target = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar-for-target)" {
-    local ar-for-target-native = [ path.native "$(ar-for-target)" ] ;
-    OPTIONS on $(targets) += "AR_FOR_TARGET='$(ar-for-target-native)'" ;
+  local ar-for-target-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-for-target-command-substitution)" {
+    OPTIONS on $(targets) += "AR_FOR_TARGET=\"$(ar-for-target-command-substitution)\"" ;
   }
 
-  local ranlib-for-target = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib-for-target)" {
-    local ranlib-for-target-native = [ path.native "$(ranlib-for-target)" ] ;
-    OPTIONS on $(targets) += "RANLIB_FOR_TARGET='$(ranlib-for-target-native)'" ;
+  local ranlib-for-target-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-for-target-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB_FOR_TARGET=\"$(ranlib-for-target-command-substitution)\"" ;
   }
 
-  local nm-for-target = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm-for-target)" {
-    local nm-for-target-native = [ path.native "$(nm-for-target)" ] ;
-    OPTIONS on $(targets) += "NM_FOR_TARGET='$(nm-for-target-native)'" ;
+  local nm-for-target-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-for-target-command-substitution)" {
+    OPTIONS on $(targets) += "NM_FOR_TARGET=\"$(nm-for-target-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/gmp/jamfile
+++ b/gmp/jamfile
@@ -16,9 +16,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -176,22 +176,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/icu4c/jamfile
+++ b/icu4c/jamfile
@@ -16,9 +16,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -286,22 +286,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/isl/jamfile
+++ b/isl/jamfile
@@ -16,9 +16,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -245,22 +245,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/mpc/jamfile
+++ b/mpc/jamfile
@@ -16,9 +16,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -269,22 +269,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/mpfr/jamfile
+++ b/mpfr/jamfile
@@ -16,9 +16,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -283,22 +283,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/opencv/jamfile
+++ b/opencv/jamfile
@@ -15,9 +15,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -230,22 +230,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "-D CMAKE_CXX_FLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/openmpi/jamfile
+++ b/openmpi/jamfile
@@ -14,9 +14,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-triplets
     get-cc
     get-cxx
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -248,22 +248,19 @@ rule make-install ( targets * : sources * : properties * )
     errors.error "`<address-model>$(address-model)': unknown property" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/ppl/jamfile
+++ b/ppl/jamfile
@@ -16,9 +16,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-cflags
     get-cxx
     get-cxxflags
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -287,22 +287,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXXFLAGS='@$(objdir-native)/cxxflags'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;

--- a/valgrind/jamfile
+++ b/valgrind/jamfile
@@ -14,9 +14,9 @@ import "$(INTRO_ROOT_DIR)/compilers"
     get-triplets
     get-cc
     get-cxx
-    get-ar
-    get-ranlib
-    get-nm
+    get-ar-command-substitution
+    get-ranlib-command-substitution
+    get-nm-command-substitution
     get-environment-commands
     get-property-dump-commands
   ;
@@ -273,22 +273,19 @@ rule make-install ( targets * : sources * : properties * )
     OPTIONS on $(targets) += "CXX='$(cxx-native)'" ;
   }
 
-  local ar = [ get-ar "$(PREFIX)" : $(properties) ] ;
-  if "$(ar)" {
-    local ar-native = [ path.native "$(ar)" ] ;
-    OPTIONS on $(targets) += "AR='$(ar-native)'" ;
+  local ar-command-substitution = [ get-ar-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ar-command-substitution)" {
+    OPTIONS on $(targets) += "AR=\"$(ar-command-substitution)\"" ;
   }
 
-  local ranlib = [ get-ranlib "$(PREFIX)" : $(properties) ] ;
-  if "$(ranlib)" {
-    local ranlib-native = [ path.native "$(ranlib)" ] ;
-    OPTIONS on $(targets) += "RANLIB='$(ranlib-native)'" ;
+  local ranlib-command-substitution = [ get-ranlib-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(ranlib-command-substitution)" {
+    OPTIONS on $(targets) += "RANLIB=\"$(ranlib-command-substitution)\"" ;
   }
 
-  local nm = [ get-nm "$(PREFIX)" : $(properties) ] ;
-  if "$(nm)" {
-    local nm-native = [ path.native "$(nm)" ] ;
-    OPTIONS on $(targets) += "NM='$(nm-native)'" ;
+  local nm-command-substitution = [ get-nm-command-substitution "$(PREFIX)" : $(properties) ] ;
+  if "$(nm-command-substitution)" {
+    OPTIONS on $(targets) += "NM=\"$(nm-command-substitution)\"" ;
   }
 
   local environment-commands = [ get-environment-commands "$(PREFIX)" : $(properties) ] ;


### PR DESCRIPTION
- compilers.jam: Renamed `get-ar`, `get-ranlib` and `get-nm` rules to
               `get-ar-command-substitution`,
               `get-ranlib-command-substitution` and
               `get-nm-command-substitution`, respectively. If the
               underlying Binutils tools (`ar`, `ranlib` and `nm`) for
               `gcc-ar`, `gcc-ranlib` and `gcc-nm` wrapper commands do not
               have plugin support, the wrapper commands do not work.
               Therefore, the renamed rules provide command substitution
               to produce suitable values for `AR`, `RANLIB`, `NM`,
               `AR_FOR_TARGET`, `RANLIB_FOR_TARGET` and `NM_FOR_TARGET`
               environment variables according to plugin support in
               the underlying Binutils tools.
- binutils/jamfile: Replaced invocations of `get-ar`, `get-ranlib` and
                  `get-nm` rules with ones of
                  `get-ar-command-substitution`,
                  `get-ranlib-command-substitution` and
                  `get-nm-command-substitution`, respectively.
- clang/jamfile: Likewise.
- cloog/jamfile: Likewise.
- gdb/jamfile: Likewise.
- gmp/jamfile: Likewise.
- icu4c/jamfile: Likewise.
- isl/jamfile: Likewise.
- mpc/jamfile: Likewise.
- mpfr/jamfile: Likewise.
- opencv/jamfile: Likewise.
- openmpi/jamfile: Likewise.
- ppl/jamfile: Likewise.
- valgrind/jamfile: Likewise.
