### PR TITLE
Added support of `--enable-valgrind-regtest` option.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -472,6 +472,9 @@ for arg in "${args[@]}"; do
       yes)
         valgrind_regtest=yes
         ;;
+      ignore-errors)
+        valgrind_regtest=ignore-errors
+        ;;
       no)
         valgrind_regtest=no
         ;;
@@ -757,6 +760,13 @@ yes)
     exit 1
   }
   delegated_opts=("${delegated_opts[@]}" --enable-valgrind-regtest)
+  ;;
+ignore-errors)
+  [ -z "$valgrind" ] && {
+    echo "bootstrap: \`--enable-valgrind-regtest' without \`--enable-valgrind'" >&2
+    exit 1
+  }
+  delegated_opts=("${delegated_opts[@]}" --enable-valgrind-regtest=ignore-errors)
   ;;
 no)
   delegated_opts=("${delegated_opts[@]}" --disable-valgrind-regtest)

--- a/jamroot
+++ b/jamroot
@@ -874,11 +874,14 @@ for local arg in [ modules.peek : ARGV ] {
   else if "$(arg)" = --enable-valgrind-regtest=yes {
     valgrind-regtest = yes ;
   }
+  else if "$(arg)" = --enable-valgrind-regtest=ignore-errors {
+    valgrind-regtest = ignore-errors ;
+  }
   else if "$(arg)" = --enable-valgrind-regtest=no {
     valgrind-regtest = no ;
   }
   else if [ regex.match "^--enable-valgrind-regtest=(.+)" : "$(arg)" : 1 ] {
-    errors.error "option `--enable-valgrind-regtest' doesn't allow an argument other than `yes' or `no'" ;
+    errors.error "option `--enable-valgrind-regtest' doesn't allow an argument other than `yes', `ignore-errors' or `no'" ;
   }
   else if "$(arg)" = --disable-valgrind-regtest {
     valgrind-regtest = no ;
@@ -898,7 +901,7 @@ if ! "$(valgrind-regtest)" {
     valgrind-regtest = no ;
   }
 }
-if ! "$(valgrind)" && "$(valgrind-regtest)" = yes {
+if ! "$(valgrind)" && "$(valgrind-regtest)" != no {
   errors.error "`--enable-valgrind-regtest' without `--enable-valgrind'" ;
 }
 ECHO valgrind-regtest... $(valgrind-regtest) ;

--- a/valgrind/jamfile
+++ b/valgrind/jamfile
@@ -73,7 +73,7 @@ $(PROPERTY_DUMP_COMMANDS)
   set -ex
   rm -f '$(<)'
   trap "rm -f '$(<)'" ERR HUP INT QUIT TERM
-  ( cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(URL)' )
+  (cd '$(<:D)' && wget -q -t 3 --no-clobber -- '$(URL)')
   [ -f '$(<)' ]
 EOS
 }
@@ -323,20 +323,31 @@ $(PROPERTY_DUMP_COMMANDS)
   [ "`/bin/sh '$(OBJDIR)/config.sub' '$(BUILD_TRIPLET)'`" = '$(BUILD_TRIPLET)' ]
   [ "`/bin/sh '$(OBJDIR)/config.sub' '$(HOST_TRIPLET)'`" = '$(HOST_TRIPLET)' ]
 
-  ( cd '$(OBJDIR)' && ./configure $(OPTIONS) )
+  (cd '$(OBJDIR)' && ./configure $(OPTIONS:J= ))
 
   # Checks the creation of `Makefile`.
   [ -f '$(OBJDIR)/Makefile' ]
 
-  ( cd '$(OBJDIR)' && make --jobs=$(CONCURRENCY) )
+  (cd '$(OBJDIR)' && make --jobs=$(CONCURRENCY))
 
-  ( cd '$(OBJDIR)' && make --jobs=$(CONCURRENCY) check )
+  (cd '$(OBJDIR)' && make --jobs=$(CONCURRENCY) check)
 
-  ( cd '$(OBJDIR)' && make install )
+  (cd '$(OBJDIR)' && make install)
 
-  if [ $(VALGRIND_REGTEST) = yes ]; then
+  if [ $(VALGRIND_REGTEST) = yes -o $(VALGRIND_REGTEST) = ignore-errors ]; then
     # Some tests might deadlock with GCC 4.8. Forces the deadlocked tests to be killed by `ulimit'.
-    ( cd '$(OBJDIR)' && ulimit -S -t 60 && ulimit -S -m 2097152 && make --jobs=$(CONCURRENCY) regtest )
+    case $(VALGRIND_REGTEST) in
+    yes)
+      (cd '$(OBJDIR)' && ulimit -S -t 60 && ulimit -S -m 2097152 && make --jobs=$(CONCURRENCY) regtest)
+      ;;
+    ignore-errors)
+      (cd '$(OBJDIR)' && ulimit -S -t 60 && ulimit -S -m 2097152 && make --jobs=$(CONCURRENCY) regtest || true)
+      ;;
+    *)
+      echo "valgrind/jamfile: an internal error" >&2
+      exit 1
+      ;;
+    esac
   fi
 
   # Cleans up `objdir`.


### PR DESCRIPTION
- bootstrap: Added the support of `--enable-valgrind-regtest` and
           `--disable-valgrind-regtest` command line options.
- jamroot:
  - Added the support of `--disable-valgrind` command line option.
  - Only the last one of `--enable-valgrind` and `--disable-valgrind`
    command line options is effective.
  - Removed the use of `option.get` rule because it reconizes
    `--enable-valgrind-regtest` command line option as `--enable-valgrind`
    with the argument `-regtest`.
  - Added the support of `--enable-valgrind-regtest` and
    `--disable-valgrind-regtest` command line options.
  - Added `VALGRIND_REGTEST` global constant.
- valgrind/jamfile: Made `make regtest` skipped if `VALGRIND_REGTEST` is
                  not equal to `yes`.
