### PR TITLE
Renamed option `--with-gcc-check` to `--enable-gcc-check`.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -31,8 +31,8 @@ args=`getopt                       \
       -l disable-multitarget       \
       -l with-gold::               \
       -l without-gold              \
-      -l with-gcc-check::          \
-      -l without-gcc-check         \
+      -l enable-gcc-check::        \
+      -l disable-gcc-check         \
       -l enable-lcov::             \
       -l enable-gcovr::            \
       -l enable-gdb::              \
@@ -72,7 +72,7 @@ cloog_for_gcc=system
 compilers=
 multitarget=no
 gold=no
-gcc_check=yes
+gcc_check=
 lcov=
 gcovr=
 gdb=
@@ -141,10 +141,10 @@ for arg in "${args[@]}"; do
     --without-gold)
       gold=no
       ;;
-    --with-gcc-check)
-      prev_arg=--with-gcc-check
+    --enable-gcc-check)
+      prev_arg=--enable-gcc-check
       ;;
-    --without-gcc-check)
+    --disable-gcc-check)
       gcc_check=no
       ;;
     --enable-lcov)
@@ -297,7 +297,7 @@ for arg in "${args[@]}"; do
       echo "bootstrap: an internal error" >&2
       exit 1
       ;;
-    --with-gcc-check)
+    --enable-gcc-check)
       case "$arg" in
       '')
         gcc_check=yes
@@ -309,12 +309,12 @@ for arg in "${args[@]}"; do
         gcc_check=no
         ;;
       *)
-        echo "bootstrap: option \`--with-gcc-check' doesn't allow argument \`$arg'" >&2
+        echo "bootstrap: option \`--enable-gcc-check' doesn't allow argument \`$arg'" >&2
         exit 1
         ;;
       esac
       ;;
-    --without-gcc-check)
+    --disable-gcc-check)
       echo "bootstrap: an internal error" >&2
       exit 1
       ;;
@@ -598,17 +598,20 @@ no)
   ;;
 esac
 
+if [ -z "$gcc_check" ]; then
+    gcc_check=yes
+fi
 case "$gcc_check" in
 yes)
-  delegated_opts=("${delegated_opts[@]}" --with-gcc-check)
-  ;;
+    delegated_opts=("${delegated_opts[@]}" --enable-gcc-check)
+    ;;
 no)
-  delegated_opts=("${delegated_opts[@]}" --without-gcc-check)
-  ;;
+    delegated_opts=("${delegated_opts[@]}" --disable-gcc-check)
+    ;;
 *)
-  echo "bootstrap: an internal error" >&2
-  exit 1
-  ;;
+    echo "bootstrap: an internal error" >&2
+    exit 1
+    ;;
 esac
 
 if [ -n "$lcov" ]; then

--- a/jamroot
+++ b/jamroot
@@ -380,52 +380,36 @@ case "*" :
 ECHO with-gold... $(with-gold) ;
 
 
-local gcc-check = [ option.get "with-gcc-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-switch "$(gcc-check)" {
-case "UNSPECIFIED" :
-  gcc-check = [ option.get "without-gcc-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gcc-check)" {
-  case "UNSPECIFIED" :
-    gcc-check = "yes" ;
-  case "IMPLIED" :
-    gcc-check = "no" ;
-  case "*" :
-    errors.error "`--without-gcc-check' cannot have any value." ;
+local gcc-check ;
+for local arg in [ modules.peek : ARGV ] {
+  if "$(arg)" = --enable-gcc-check {
+    gcc-check = yes ;
   }
-case "IMPLIED" :
-  gcc-check = [ option.get "without-gcc-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gcc-check)" {
-  case "UNSPECIFIED" :
-    gcc-check = "yes" ;
-  case "IMPLIED" :
-    errors.error "`--with-gcc-check' and `--without-gcc-check' cannot be specified simultaneously." ;
-  case "*" :
-    errors.error "`--without-gcc-check' cannot have any value." ;
+  else if "$(arg)" = --enable-gcc-check= {
+    errors.error "option `--enable-gcc-check' doesn't allow empty argument" ;
   }
-case "yes" :
-  gcc-check = [ option.get "without-gcc-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gcc-check)" {
-  case "UNSPECIFIED" :
-    gcc-check = "yes" ;
-  case "IMPLIED" :
-    errors.error "`--with-gcc-check' and `--without-gcc-check' cannot be specified simultaneously." ;
-  case "*" :
-    errors.error "`--without-gcc-check' cannot have any value." ;
+  else if "$(arg)" = --enable-gcc-check=yes {
+    gcc-check = yes ;
   }
-case "no" :
-  gcc-check = [ option.get "without-gcc-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gcc-check)" {
-  case "UNSPECIFIED" :
-    gcc-check = "no" ;
-  case "IMPLIED" :
-    errors.error "`--with-gcc-check' and `--without-gcc-check' cannot be specified simultaneously." ;
-  case "*" :
-    errors.error "`--without-gcc-check' cannot have any value." ;
+  else if "$(arg)" = --enable-gcc-check=no {
+    gcc-check = no ;
   }
-case "" :
-  errors.error "the value for `--with-gcc-check' is an empty string." ;
-case "*" :
-  errors.error "an invalid value `$(gcc-check)' is specified for `--with-gcc-check'." ;
+  else if [ regex.match "^--enable-gcc-check=(.+)" : "$(arg)" : 1 ] {
+    local v = [ regex.match "^--enable-gcc-check=(.+)" : "$(arg)" : 1 ] ;
+    errors.error "option `--enable-gcc-check' doesn't allow argument `$(v)'" ;
+  }
+  else if "$(arg)" = --disable-gcc-check {
+    gcc-check = no ;
+  }
+  else if [ regex.match "(^--disable-gcc-check=.*)" : "$(arg)" : 1 ] {
+    errors.error "option `--disable-gcc-check' doesn't allow an argument" ;
+  }
+  else {
+    # Do nothing.
+  }
+}
+if ! "$(gcc-check)" {
+  gcc-check = yes ;
 }
 ECHO gcc-check... $(gcc-check) ;
 


### PR DESCRIPTION
- bootstrap: Renamed command line options `--with-gcc-check` and
           `--without-gcc-check` to `--enable-gcc-check` and
           `--disable-gcc-check`, respectively.
- jamroot:
  - Renamed command line options `--with-gcc-check` and
    `--without-gcc-check` to `--enable-gcc-check` and `--disable-gcc-check`,
    respectively.
  - Only the last one of `--enable-gcc-check` and `--disable-gcc-check`
    command line options is effective.
