### PR TITLE
Renamed option `--with-gdb-check` to `--enable-gdb-check`.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -36,8 +36,9 @@ args=`getopt                       \
       -l enable-lcov::             \
       -l enable-gcovr::            \
       -l enable-gdb::              \
-      -l with-gdb-check::          \
-      -l without-gdb-check         \
+      -l disable-gdb               \
+      -l enable-gdb-check::        \
+      -l disable-gdb-check         \
       -l enable-gmp::              \
       -l enable-mpfr::             \
       -l enable-mpc::              \
@@ -76,7 +77,7 @@ gcc_check=
 lcov=
 gcovr=
 gdb=
-gdb_check=yes
+gdb_check=
 gmp=
 mpfr=
 mpc=
@@ -156,10 +157,13 @@ for arg in "${args[@]}"; do
     --enable-gdb)
       prev_arg=--enable-gdb
       ;;
-    --with-gdb-check)
-      prev_arg=--with-gdb-check
+    --disable-gdb)
+      gdb=
       ;;
-    --without-gdb-check)
+    --enable-gdb-check)
+      prev_arg=--enable-gdb-check
+      ;;
+    --disable-gdb-check)
       gdb_check=no
       ;;
     --enable-gmp)
@@ -339,7 +343,11 @@ for arg in "${args[@]}"; do
         gdb="$arg"
       fi
       ;;
-    --with-gdb-check)
+    --disable-gdb)
+      echo "bootstrap: an internal error" >&2
+      exit 1
+      ;;
+    --enable-gdb-check)
       case "$arg" in
       '')
         gdb_check=yes
@@ -351,10 +359,14 @@ for arg in "${args[@]}"; do
         gdb_check=no
         ;;
       *)
-        echo "bootstrap: option \`--with-gdb-check' doesn't allow argument \`$arg'" >&2
+        echo "bootstrap: option \`--enable-gdb-check' doesn't allow argument \`$arg'" >&2
         exit 1
         ;;
       esac
+      ;;
+    --disable-gdb-check)
+      echo "bootstrap: an internal error" >&2
+      exit 1
       ;;
     --enable-opencv)
       if [ -z "$arg" ]; then
@@ -654,18 +666,41 @@ if [ -n "$gdb" ]; then
     delegated_opts=("${delegated_opts[@]}" --enable-gdb="$gdb")
 fi
 
-case "$gdb_check" in
-yes)
-  delegated_opts=("${delegated_opts[@]}" --with-gdb-check)
-  ;;
-no)
-  delegated_opts=("${delegated_opts[@]}" --without-gdb-check)
-  ;;
-*)
-  echo 'bootstrap: an internal error' >&2
-  exit 1
-  ;;
-esac
+if [ -n "$gdb" ]; then
+    case "$gdb_check" in
+    yes)
+        delegated_opts=("${delegated_opts[@]}" --enable-gdb-check)
+        ;;
+    no)
+        delegated_opts=("${delegated_opts[@]}" --disable-gdb-check)
+        ;;
+    '')
+        # Do nothing.
+        ;;
+    *)
+        echo 'bootstrap: an internal error' >&2
+        exit 1
+        ;;
+    esac
+else
+    case "$gdb_check" in
+    yes)
+        echo "bootstrap: \`--enable-gdb-check' without \`--enable-gdb'" >&2
+        exit 1
+        ;;
+    no)
+        echo "bootstrap: \`--disable-gdb-check' without \`--enable-gdb'" >&2
+        exit 1
+        ;;
+    '')
+        # Do nothing.
+        ;;
+    *)
+        echo 'bootstrap: an internal error' >&2
+        exit 1
+        ;;
+    esac
+fi
 
 if [ -n "$gmp" ]; then
   if [ "$gmp" = latest ]; then

--- a/jamroot
+++ b/jamroot
@@ -444,9 +444,26 @@ else {
 }
 
 
-local gdb = [ option.get enable-gdb : : IMPLIED ] ;
-if "$(gdb)" = IMPLIED {
-  errors.error "`--enable-gdb' should be specified with a value" ;
+local gdb ;
+for local arg in [ modules.peek : ARGV ] {
+  if "$(arg)" = --enable-gdb {
+    errors.error "option `--enable-gdb' requires an argument" ;
+  }
+  else if "$(arg)" = --enable-gdb= {
+    errors.error "option `--enable-gdb' doesn't allow empty argument" ;
+  }
+  else if [ regex.match "^--enable-gdb=(.+)" : "$(arg)" : 1 ] {
+    gdb = [ regex.match "^--enable-gdb=(.+)" : "$(arg)" : 1 ] ;
+  }
+  else if "$(arg)" = --disable-gdb {
+    gdb = ;
+  }
+  else if [ regex.match "(^--disable-gdb=.*)" : "$(arg)" : 1 ] {
+    errors.error "option `--disable-gdb' doesn't allow an argument" ;
+  }
+  else {
+    # Do nothing.
+  }
 }
 if "$(gdb)" {
   # GDB version strings might include non-digit suffixes like `7.3a`.
@@ -455,56 +472,56 @@ if "$(gdb)" {
   }
   ECHO gdb... $(gdb) ;
 }
-
-
-local gdb-check = [ option.get "with-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-switch "$(gdb-check)" {
-case "UNSPECIFIED" :
-  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gdb-check)" {
-  case "UNSPECIFIED" :
-    gdb-check = "yes" ;
-  case "IMPLIED" :
-    gdb-check = "no" ;
-  case "*" :
-    errors.error "`--without-gdb-check' cannot have any value." ;
-  }
-case "IMPLIED" :
-  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gdb-check)" {
-  case "UNSPECIFIED" :
-    gdb-check = "yes" ;
-  case "IMPLIED" :
-    errors.error "`--with-gdb-check' and `--without-gdb-check' cannot be specified simultaneously." ;
-  case "*" :
-    errors.error "`--without-gdb-check' cannot have any value." ;
-  }
-case "yes" :
-  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gdb-check)" {
-  case "UNSPECIFIED" :
-    gdb-check = "yes" ;
-  case "IMPLIED" :
-    errors.error "`--with-gdb-check' and `--without-gdb-check' cannot be specified simultaneously." ;
-  case "*" :
-    errors.error "`--without-gdb-check' cannot have any value." ;
-  }
-case "no" :
-  gdb-check = [ option.get "without-gdb-check" : "UNSPECIFIED" : "IMPLIED" ] ;
-  switch "$(gdb-check)" {
-  case "UNSPECIFIED" :
-    gdb-check = "no" ;
-  case "IMPLIED" :
-    errors.error "`--with-gdb-check' and `--without-gdb-check' cannot be specified simultaneously." ;
-  case "*" :
-    errors.error "`--without-gdb-check' cannot have any value." ;
-  }
-case "" :
-  errors.error "the value for `--with-gdb-check' is an empty string." ;
-case "*" :
-  errors.error "an invalid value `$(gdb-check)' is specified for `--with-gdb-check'." ;
+else {
+  ECHO gdb... N/A ;
 }
-ECHO gdb-check... $(gdb-check) ;
+
+
+local gdb-check ;
+for local arg in [ modules.peek : ARGV ] {
+  if "$(arg)" = --enable-gdb-check {
+    gdb-check = yes ;
+  }
+  else if "$(arg)" = --enable-gdb-check= {
+    errors.error "option `--enable-gdb-check' doesn't allow empty argument" ;
+  }
+  else if "$(arg)" = --enable-gdb-check=yes {
+    gdb-check = yes ;
+  }
+  else if "$(arg)" = --enable-gdb-check=no {
+    gdb-check = no ;
+  }
+  else if [ regex.match "^--enable-gdb-check=(.+)" : "$(arg)" : 1 ] {
+    local v = [ regex.match "^--enable-gdb-check=(.+)" : "$(arg)" : 1 ] ;
+    errors.error "option `--enable-gdb-check' doesn't allow argument `$(v)'" ;
+  }
+  else if "$(arg)" = --disable-gdb-check {
+    gdb-check = no ;
+  }
+  else if [ regex.match "(^--disable-gdb-check=.*)" : "$(arg)" : 1 ] {
+    errors.error "option `--disable-gdb-check' doesn't allow an argument" ;
+  }
+  else {
+    # Do nothing.
+  }
+}
+if "$(gdb)" {
+  gdb-check ?= yes ;
+  ECHO gdb-check... $(gdb-check) ;
+}
+else {
+  switch "$(gdb-check)" {
+  case yes :
+    errors.error "`--enable-gdb-check' without `--enable-gdb'" ;
+  case no :
+    errors.error "`--disable-gdb-check' without `--enable-gdb'" ;
+  case "" :
+    gdb-check = no ;
+    ECHO gdb-check... N/A ;
+  case * :
+    errors.error "an internal error" ;
+  }
+}
 
 
 local gmp = [ option.get enable-gmp : : IMPLIED ] ;


### PR DESCRIPTION
- bootstrap:
  - Added the support of `--disable-gdb` command line option.
  - Renamed command line options `--with-gdb-check` and
    `--without-gdb-check` to `--enable-gdb-check` and `--disable-gdb-check`,
    respectively.
- jamroot:
  - Added the support of `--disable-gdb` command line option.
  - Only the last one of `--enable-gdb` and `--disable-gdb` command line
    options is effective.
  - Rename command line options `--with-gdb-check` and `--without-gdb-check`
    to `--enable-gdb-check` and `--disable-gdb-check`, respectively.
  - Only the last one of `--enable-gdb-check` and `--disable-gdb-check`
    command line options is effective.
