### PR TITLE
Added support of `--disable-cloog` option.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -44,6 +44,7 @@ args=`getopt                       \
       -l enable-mpc::              \
       -l enable-isl::              \
       -l enable-cloog::            \
+      -l disable-cloog             \
       -l enable-ppl::              \
       -l enable-icu4c::            \
       -l enable-openmpi::          \
@@ -180,6 +181,9 @@ for arg in "${args[@]}"; do
       ;;
     --enable-cloog)
       prev_arg=--enable-cloog
+      ;;
+    --disable-cloog)
+      cloog=
       ;;
     --enable-ppl)
       prev_arg=--enable-ppl
@@ -741,6 +745,8 @@ if [ -n "$cloog" ]; then
     exit 1
   fi
   delegated_opts=("${delegated_opts[@]}" --enable-cloog="$cloog")
+else
+  delegated_opts=("${delegated_opts[@]}" --disable-cloog)
 fi
 
 if [ -n "$ppl" ]; then

--- a/jamroot
+++ b/jamroot
@@ -632,9 +632,26 @@ if "$(isl)" {
 }
 
 
-local cloog = [ option.get enable-cloog : : IMPLIED ] ;
-if "$(cloog)" = IMPLIED {
-  errors.error "`--enable-cloog' should be specified with a value" ;
+local cloog ;
+for local arg in [ modules.peek : ARGV ] {
+  if "$(arg)" = --enable-cloog {
+    errors.error "option `--enable-cloog' requires an argument" ;
+  }
+  else if "$(arg)" = --enable-cloog= {
+    errors.error "option `--enable-cloog' doesn't allow empty argument" ;
+  }
+  else if [ regex.match "^--enable-cloog=(.+)" : "$(arg)" : 1 ] {
+    cloog = [ regex.match "^--enable-cloog=(.+)" : "$(arg)" : 1 ] ;
+  }
+  else if "$(arg)" = --disable-cloog {
+    cloog = ;
+  }
+  else if [ regex.match "(^--disable-cloog=.*)" : "$(arg)" : 1 ] {
+    errors.error "option `--disable-cloog' doesn't allow an argument" ;
+  }
+  else {
+    # Do nothing.
+  }
 }
 if $(cloog) {
   if [ regex.match "^([0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)$" : "$(cloog)" : 1 ] {
@@ -644,7 +661,7 @@ if $(cloog) {
     # Do nothing.
   }
   else {
-    errors.error "an invalid value `$(cloog)' for `--enable-cloog'." ;
+    errors.error "an invalid value `$(cloog)' for `--enable-cloog'" ;
   }
   if ! "$(cloog)" in $(cloog-versions) {
     cloog-versions += "$(cloog)" ;


### PR DESCRIPTION
* bootstrap: Added the support of `--disable-cloog` command line option.
* jamroot:
  * Added the support of `--disable-cloog` command line option.
  * Only the last one of `--enable-cloog` and `--disable-cloog` command line
    options is effective.