### PR TITLE
Disabled versioned namespace for GCC 5 or above.

### DIFF
--- a/gcc/jamfile
+++ b/gcc/jamfile
@@ -4,6 +4,7 @@ import alias ;
 import errors ;
 import feature ;
 import make ;
+import numbers ;
 import path ;
 import regex ;
 import "$(INTRO_ROOT_DIR)/compilers"
@@ -421,7 +422,10 @@ rule make-install ( targets * : sources * : properties * )
 
   OPTIONS on $(targets) += "--enable-libstdcxx-debug" ;
 
-  OPTIONS on $(targets) += "--enable-symvers=gnu-versioned-namespace" ;
+  local version_major = [ regex.match "^([0-9]+)" : "$(version)" : 1 ] ;
+  if [ numbers.less "$(version_major)" 5 ] {
+    OPTIONS on $(targets) += "--enable-symvers=gnu-versioned-namespace" ;
+  }
 
   PROPERTY_DUMP_COMMANDS on $(targets) = [ get-property-dump-commands $(properties) ] ;
 }


### PR DESCRIPTION
* gcc/jamfile: The option `--enable-symvers=gnu-versioned-namespace` had
               been explicitly specified in order to detect code based on a
               wrong assumption that entities in the standard library are
               declared directly below `std` namespace. However, dual ABI
               has been implemented on GCC 5 or above, and versioned
               namespace is implicitly used for C++11-compliant standard
               library implementation. Therefore, explicit specification of
               the option is no longer needed for GCC 5 or above.